### PR TITLE
Change Dates to ISO Strings

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/CreationDetails.java
+++ b/src/main/java/com/redhat/labs/omp/model/CreationDetails.java
@@ -1,7 +1,5 @@
 package com.redhat.labs.omp.model;
 
-import java.time.LocalDateTime;
-
 import javax.json.bind.annotation.JsonbProperty;
 
 import lombok.AllArgsConstructor;
@@ -20,6 +18,6 @@ public class CreationDetails {
     @JsonbProperty("created_by_email")
     private String createdByEmail;
     @JsonbProperty("created_on")
-    private LocalDateTime createdOn;
+    private String createdOn;
 
 }

--- a/src/main/java/com/redhat/labs/omp/model/Launch.java
+++ b/src/main/java/com/redhat/labs/omp/model/Launch.java
@@ -1,7 +1,5 @@
 package com.redhat.labs.omp.model;
 
-import java.time.LocalDateTime;
-
 import javax.json.bind.annotation.JsonbProperty;
 
 import lombok.AllArgsConstructor;
@@ -16,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Launch {
 
     @JsonbProperty("launched_date_time")
-    private LocalDateTime launchedDateTime;
+    private String launchedDateTime;
     @JsonbProperty("launched_by")
     private String launchedBy;
 

--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -1,6 +1,7 @@
 package com.redhat.labs.omp.service;
 
-import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -271,7 +272,7 @@ public class EngagementService {
         }
 
         // create new launch data for engagement
-        engagement.setLaunch(Launch.builder().launchedDateTime(LocalDateTime.now())
+        engagement.setLaunch(Launch.builder().launchedDateTime(ZonedDateTime.now(ZoneId.of("Z")).toString())
                 .launchedBy(engagement.getLastUpdateByName()).build());
 
         // update db

--- a/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
+++ b/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
@@ -1,6 +1,7 @@
 package com.redhat.labs.omp.service;
 
-import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -61,8 +62,7 @@ public class GitSyncService {
 
         }).subscribe().with(item -> {
             // create refresh event
-            BackendEvent refreshDbEvent = BackendEvent.createDatabaseRefreshEvent(item,
-                    event.isForceUpdate());
+            BackendEvent refreshDbEvent = BackendEvent.createDatabaseRefreshEvent(item, event.isForceUpdate());
             // send event to bus for processing
             eventBus.sendAndForget(refreshDbEvent.getEventType().getEventBusAddress(), refreshDbEvent);
         }, failure -> {
@@ -174,7 +174,8 @@ public class GitSyncService {
 
         // set creation details
         CreationDetails creationDetails = CreationDetails.builder().createdByUser(engagement.getLastUpdateByName())
-                .createdByEmail(engagement.getLastUpdateByEmail()).createdOn(LocalDateTime.now()).build();
+                .createdByEmail(engagement.getLastUpdateByEmail())
+                .createdOn(ZonedDateTime.now(ZoneId.of("Z")).toString()).build();
         engagement.setCreationDetails(creationDetails);
 
     }


### PR DESCRIPTION
- store dates as ISO strings
- initial creation and launch dates will have date, time, and UTC/Z timezone