### PR TITLE
Restore Immutable Engagment Fields and Minor Updates

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/Launch.java
+++ b/src/main/java/com/redhat/labs/omp/model/Launch.java
@@ -17,5 +17,7 @@ public class Launch {
     private String launchedDateTime;
     @JsonbProperty("launched_by")
     private String launchedBy;
+    @JsonbProperty("launched_by_email")
+    private String launchedByEmail;
 
 }

--- a/src/main/java/com/redhat/labs/omp/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/omp/resource/EngagementResource.java
@@ -41,7 +41,7 @@ import com.redhat.labs.omp.service.EngagementService;
 @SecurityScheme(securitySchemeName = "jwt", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
 public class EngagementResource {
 
-    private static final String USERNAME_CLAIM = "preferred_username";
+    private static final String NAME_CLAIM = "name";
     private static final String USER_EMAIL_CLAIM = "email";
 
     public static final String DEFAULT_USERNAME = "omp-user";
@@ -158,8 +158,8 @@ public class EngagementResource {
     }
 
     private String getUsernameFromToken() {
-        Optional<String> optional = jwt.claim(USERNAME_CLAIM);
-        return optional.isPresent() ? optional.get() : DEFAULT_USERNAME;
+        Optional<String> optional = jwt.claim(NAME_CLAIM);
+        return optional.isPresent() ? optional.get() : getUserEmailFromToken();
     }
 
     private String getUserEmailFromToken() {

--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -60,7 +60,7 @@ public class EngagementService {
 
     @Inject
     EngagementEventSocket socket;
-    
+
     @Inject
     @RestClient
     OMPGitLabAPIService gitApi;
@@ -72,7 +72,7 @@ public class EngagementService {
      * @param engagement
      * @return
      */
-    
+
     public Engagement create(Engagement engagement) {
 
         // check if engagement exists
@@ -120,36 +120,54 @@ public class EngagementService {
         // set engagement id in case it was updated before the consumer refreshed
         engagement.setProjectId(persisted.getProjectId());
 
+        // set creation details
+        engagement.setCreationDetails(persisted.getCreationDetails());
+
+        // set launch details
+        if (null != persisted.getLaunch()) {
+            engagement.setLaunch(persisted.getLaunch());
+        }
+
+        // set commits
+        if (null != persisted.getCommits()) {
+            engagement.setCommits(persisted.getCommits());
+        }
+
+        // set status
+        if (null != persisted.getStatus()) {
+            engagement.setStatus(persisted.getStatus());
+        }
+
         // update in db
         repository.update(engagement);
 
         return engagement;
 
     }
-    
-    //Status comes from gitlab so it does not need to to be sync'd
+
+    // Status comes from gitlab so it does not need to to be sync'd
     public Engagement updateStatusAndCommits(Hook hook) {
 
         Optional<Engagement> optional = get(hook.getCustomerName(), hook.getEngagementName());
         if (!optional.isPresent()) {
             throw new ResourceNotFoundException("no engagement found. unable to update from hook.");
         }
-        
+
         Engagement persisted = optional.get();
-        
-        if(hook.didFileChange(statusFile)) {
+
+        if (hook.didFileChange(statusFile)) {
             Status status = gitApi.getStatus(hook.getCustomerName(), hook.getEngagementName());
             persisted.setStatus(status);
         }
 
         List<Commit> commits = gitApi.getCommits(hook.getCustomerName(), hook.getEngagementName());
         persisted.setCommits(commits);
-        
+
         // update in db
         repository.update(persisted);
-        
+
         sendEngagementEvent(jsonb.toJson(persisted));
-        
+
         return persisted;
     }
 
@@ -164,9 +182,10 @@ public class EngagementService {
     public Optional<Engagement> get(String customerName, String projectName) {
 
         Optional<Engagement> optional = Optional.empty();
-        
-        if(LOGGER.isDebugEnabled()) {
-            repository.listAll().stream().forEach( engagement -> LOGGER.debug("E {} {}", engagement.getCustomerName(), engagement.getProjectName()));
+
+        if (LOGGER.isDebugEnabled()) {
+            repository.listAll().stream().forEach(
+                    engagement -> LOGGER.debug("E {} {}", engagement.getCustomerName(), engagement.getProjectName()));
         }
         // check db
         Engagement persistedEngagement = repository.findByCustomerNameAndProjectName(customerName, projectName);
@@ -187,20 +206,24 @@ public class EngagementService {
     public List<Engagement> getAll() {
         return repository.listAll();
     }
-    
+
     /**
-     * Returns a {@link List} of all customer names in the data store that match the input
-     * @param subString - A string to match the customer name on. Can be all or part. case-insensitive
-     * @return a {@link List} of all customer names in the data store that match the input
+     * Returns a {@link List} of all customer names in the data store that match the
+     * input
+     * 
+     * @param subString - A string to match the customer name on. Can be all or
+     *                  part. case-insensitive
+     * @return a {@link List} of all customer names in the data store that match the
+     *         input
      */
     public Collection<String> getSuggestions(String subString) {
-		List<Engagement> allEngagements = repository.findCustomerSuggestions(subString);
-		
-		Set<String> customers = new TreeSet<>();
-		allEngagements.stream().forEach(engagement -> customers.add(engagement.getCustomerName()));
-		
-		return customers;
-	}
+        List<Engagement> allEngagements = repository.findCustomerSuggestions(subString);
+
+        Set<String> customers = new TreeSet<>();
+        allEngagements.stream().forEach(engagement -> customers.add(engagement.getCustomerName()));
+
+        return customers;
+    }
 
     /**
      * Used by the {@link GitSyncService} to delete all {@link Engagement} from the
@@ -273,7 +296,8 @@ public class EngagementService {
 
         // create new launch data for engagement
         engagement.setLaunch(Launch.builder().launchedDateTime(ZonedDateTime.now(ZoneId.of("Z")).toString())
-                .launchedBy(engagement.getLastUpdateByName()).build());
+                .launchedBy(engagement.getLastUpdateByName()).launchedByEmail(engagement.getLastUpdateByEmail())
+                .build());
 
         // update db
         Engagement updated = update(engagement.getCustomerName(), engagement.getProjectName(), engagement);

--- a/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
@@ -798,7 +798,7 @@ public class EngagementResourceTest {
              .then()
                  .statusCode(200)
                  .body("launch.launched_date_time", notNullValue())
-                 .body("launch.launched_by", equalTo("jdoe"));
+                 .body("launch.launched_by", equalTo("John Doe"));
 
     }
 

--- a/src/test/resources/JwtClaimsWriter.json
+++ b/src/test/resources/JwtClaimsWriter.json
@@ -4,6 +4,7 @@
     "sub": "jdoe-using-jwt-rbac",
     "upn": "jdoe@quarkus.io",
     "preferred_username": "jdoe",
+    "name": "John Doe",
     "aud": "using-jwt-rbac",
     "birthdate": "2001-07-13",
     "roleMappings": {


### PR DESCRIPTION
- launch, creation, commits, and status will not be editable from an update
  - incoming data will be replaced with the data from the data store
- added launch by email
- using `user` claim for user name instead of `perferred_username` claim