### PR TITLE
🧀  Adds ability to delete engagements via Hook  🥂 

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/GitlabProject.java
+++ b/src/main/java/com/redhat/labs/omp/model/GitlabProject.java
@@ -10,5 +10,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GitlabProject {
+    private static final String REGEX = "(.*) \\/ (.*) \\/ (.*) \\/ iac";
+
     private String pathWithNamespace;
+    private String nameWithNamespace;
+    
+    public String getCustomerNameFromName() {
+        return nameWithNamespace.replaceAll(REGEX, "$2");
+    }
+    
+    public String getEngagementNameFromName() {
+        return nameWithNamespace.replaceAll(REGEX, "$3");
+    }
 }

--- a/src/main/java/com/redhat/labs/omp/model/Hook.java
+++ b/src/main/java/com/redhat/labs/omp/model/Hook.java
@@ -17,8 +17,7 @@ public class Hook {
     private String eventName;
     private List<Commit> commits;
     private GitlabProject project;
-    
-    private static final String regex = "(.*)\\/(.*)\\/(.*)\\/iac";
+    private String groupId;
     
     public boolean didFileChange(String fileName) {
         for(Commit commit : commits) {
@@ -31,12 +30,16 @@ public class Hook {
     }
     
     public String getCustomerName() {
-        return project.getPathWithNamespace().replaceAll(regex, "$2");
+        return project.getCustomerNameFromName();
         
     }
     
     public String getEngagementName() {
-        return project.getPathWithNamespace().replaceAll(regex, "$3");
+        return project.getEngagementNameFromName();
+    }
+
+    public boolean wasProjectDeleted() {
+        return "project_deleted".equals(eventName);
     }
     
 }

--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -195,9 +195,9 @@ public class EngagementService {
 
         Optional<Engagement> optional = Optional.empty();
 
-        if (LOGGER.isDebugEnabled()) {
+        if (LOGGER.isTraceEnabled()) {
             repository.listAll().stream().forEach(
-                    engagement -> LOGGER.debug("E {} {}", engagement.getCustomerName(), engagement.getProjectName()));
+                    engagement -> LOGGER.trace("E {} {}", engagement.getCustomerName(), engagement.getProjectName()));
         }
         // check db
         Engagement persistedEngagement = repository.findByCustomerNameAndProjectName(customerName, projectName);
@@ -244,6 +244,19 @@ public class EngagementService {
     void deleteAll() {
         long count = repository.deleteAll();
         LOGGER.info("removed '{}' engagements from the data store.", count);
+    }
+
+    /**
+     * This should also update clients about the delete. Need infra here
+     * @param customerName
+     * @param engagementName
+     */
+    public void delete(String customerName, String engagementName) {
+        Optional<Engagement> engagement = get(customerName, engagementName);
+        if(engagement.isPresent()) {
+            LOGGER.debug("Deleting engagement {} for customer {}", engagementName, customerName);
+            repository.delete(engagement.get());
+        }
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,7 +57,7 @@ quarkus.mongodb.connection-string=mongodb://${mongo.user}:${mongo.password}@${mo
 omp.gitlab.api/mp-rest/url=${OMP_GITLAB_API_URL:http://omp-git-api:8080}
 
 webhook.token=${WEBHOOK_TOKEN:t}
-cleanup.token=${CLEANUP_TOKEN:CLEANUP}
+cleanup.token=${CLEANUP_TOKEN:OFF}
 status.file=status.json
 
 # version

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,6 +57,7 @@ quarkus.mongodb.connection-string=mongodb://${mongo.user}:${mongo.password}@${mo
 omp.gitlab.api/mp-rest/url=${OMP_GITLAB_API_URL:http://omp-git-api:8080}
 
 webhook.token=${WEBHOOK_TOKEN:t}
+cleanup.token=${CLEANUP_TOKEN:CLEANUP}
 status.file=status.json
 
 # version

--- a/src/test/java/com/redhat/labs/omp/resources/StatusResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/StatusResourceTest.java
@@ -70,4 +70,56 @@ public class StatusResourceTest {
         .then()
             .statusCode(401);
     } 
+    
+    @Test
+    public void testDeletedHook() {
+        String body = ResourceLoader.load("StatusDeleted.json");
+        
+        given()
+        .when()
+            .contentType(ContentType.JSON)
+            .body(body)
+            .header("x-notification-token", "CLEANUP")
+            .post("/status/deleted")
+        .then()
+            .statusCode(204);
+    }
+    
+    @Test
+    public void testDeletedWrongEventType() {
+        String body = ResourceLoader.load("StatusReqValid.json");
+        
+        given()
+        .when()
+            .contentType(ContentType.JSON)
+            .body(body)
+            .header("x-notification-token", "CLEANUP")
+            .post("/status/deleted")
+        .then()
+            .statusCode(200);
+    }
+    
+    @Test
+    public void testDeletedNoEngagement() {
+        String body = ResourceLoader.load("StatusDeletedNoEngagement.json");
+        
+        given()
+        .when()
+            .contentType(ContentType.JSON)
+            .body(body)
+            .header("x-notification-token", "CLEANUP")
+            .post("/status/deleted")
+        .then()
+            .statusCode(204);
+    }
+    
+    @Test
+    public void testDeletedNoToken() {
+        given()
+        .when()
+            .contentType(ContentType.JSON)
+            .post("/status/hook")
+        .then()
+            .statusCode(401);
+    }
 }

--- a/src/test/java/com/redhat/labs/omp/service/EngagementServiceTest.java
+++ b/src/test/java/com/redhat/labs/omp/service/EngagementServiceTest.java
@@ -28,7 +28,7 @@ class EngagementServiceTest {
 	EngagementService engagementService;
 	
 	@Test void testUpdateStatusInvalidProject() {
-		Hook hook = Hook.builder().project(GitlabProject.builder().pathWithNamespace("/nope/nada/iac").build()).build();
+		Hook hook = Hook.builder().project(GitlabProject.builder().pathWithNamespace("/nope/nada/iac").nameWithNamespace("/ nope / nada / iac").build()).build();
 		
 		Exception ex = assertThrows(ResourceNotFoundException.class, ()-> {
 			engagementService.updateStatusAndCommits(hook);

--- a/src/test/resources/StatusDeleted.json
+++ b/src/test/resources/StatusDeleted.json
@@ -1,12 +1,12 @@
 {
     "object_kind": "push",
-    "event_name": "push",
+    "event_name": "project_deleted",
     "project": {
         "path_with_namespace": "butter/chomp/sandbox/jello/exists/iac",
         "name_with_namespace": "butter / chomp / sandbox / jello / exists / iac"
     },
     "commits": [{
-        "added": ["engagement.json"],
+        "added": ["status.json"],
         "modified": [],
         "removed": []
     }]

--- a/src/test/resources/StatusDeletedNoEngagement.json
+++ b/src/test/resources/StatusDeletedNoEngagement.json
@@ -1,0 +1,13 @@
+{
+    "object_kind": "push",
+    "event_name": "project_deleted",
+    "project": {
+        "path_with_namespace": "butter/chomp/sandbox/jello/doesnotexist/iac",
+        "name_with_namespace": "butter / chomp / sandbox / jello / doesnotexist / iac"
+    },
+    "commits": [{
+        "added": ["status.json"],
+        "modified": [],
+        "removed": []
+    }]
+}

--- a/src/test/resources/StatusReqValid.json
+++ b/src/test/resources/StatusReqValid.json
@@ -2,7 +2,8 @@
     "object_kind": "push",
     "event_name": "push",
     "project": {
-        "path_with_namespace": "butter/chomp/sandbox/jello/exists/iac"
+        "path_with_namespace": "butter/chomp/sandbox/jello/exists/iac",
+        "name_with_namespace": "butter / chomp / sandbox / jello / exists / iac"
     },
     "commits": [{
         "added": ["status.json"],

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -40,4 +40,5 @@ git.tag=master
 version.yml=src/test/resources/version-manifest.yaml
 status.file=status.json
 webhook.token=ttttt
+cleanup.token=CLEANUP
 


### PR DESCRIPTION
When engagements are deleted (via cronjob) they can notify the backend to remove that engagement from mongo after sharing a token.

The application can use configuration to set the token and if the token is set to the magical value of `OFF` (case sensitive) then this endpoint will be rendered useless. This will help prevent deletions in envs where they should not occur.

This also address is previous known issue where status updates could not be done for engagements with special characters. This now supports all characters by using the namespace instead of path with namespace. The namespace gives us the true customer name and engagement name.


🧀  🥂 