### PR TITLE
Concurrency Fixes for Engagement Updates

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/omp/model/Engagement.java
@@ -83,6 +83,8 @@ public class Engagement extends PanacheMongoEntityBase {
     private String lastUpdateByName;
     @JsonbProperty("last_update_by_email")
     private String lastUpdateByEmail;
+    @JsonbProperty("last_update")
+    private String lastUpdate;
 
 
     @JsonbTransient

--- a/src/main/java/com/redhat/labs/omp/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/omp/repository/EngagementRepository.java
@@ -1,8 +1,13 @@
 package com.redhat.labs.omp.repository;
 
+import static com.mongodb.client.model.Filters.eq;
+
 import java.util.List;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
+
+import org.bson.conversions.Bson;
 
 import com.redhat.labs.omp.model.Engagement;
 import com.redhat.labs.omp.model.FileAction;
@@ -27,9 +32,10 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
     public List<Engagement> findByModified() {
         return find("action is not null").list();
     }
-    
+
     /**
      * A case insensitive string to match against customer names.
+     * 
      * @param input
      * @return
      */
@@ -37,6 +43,22 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
         String queryInput = String.format("(?i)%s", input);
 
         return find("customerName like ?1", queryInput).list();
+    }
+
+    /**
+     * Returns an {@link Optional} containing the updated {@link Engagement} where
+     * last update matched. Otherwise, returns an empty {@link Optional}
+     * 
+     * @param replacement
+     * @param lastUpdate
+     * @return
+     */
+    public Optional<Engagement> replaceEngagementIfLastUpdateMatched(Engagement replacement, String lastUpdate) {
+
+        // create bson filter for last update
+        Bson filter = eq("lastUpdate", lastUpdate);
+        return Optional.ofNullable(this.mongoCollection().findOneAndReplace(filter, replacement));
+
     }
 
 }

--- a/src/main/java/com/redhat/labs/omp/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/omp/repository/EngagementRepository.java
@@ -1,14 +1,24 @@
 package com.redhat.labs.omp.repository;
 
+import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.combine;
+import static com.mongodb.client.model.Updates.set;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 
 import org.bson.conversions.Bson;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.ReturnDocument;
 import com.redhat.labs.omp.model.Engagement;
 import com.redhat.labs.omp.model.FileAction;
 
@@ -16,6 +26,11 @@ import io.quarkus.mongodb.panache.PanacheMongoRepository;
 
 @ApplicationScoped
 public class EngagementRepository implements PanacheMongoRepository<Engagement> {
+
+    public static final List<String> IMMUTABLE_FIELDS = new ArrayList<>(
+            Arrays.asList("mongoId", "projectId", "creationDetails", "status", "commits", "launch"));
+
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     public Engagement findByEngagementId(Integer engagementId) {
         return find("engagementId", engagementId).firstResult();
@@ -51,13 +66,76 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
      * 
      * @param replacement
      * @param lastUpdate
+     * @param skipLaunch
      * @return
      */
-    public Optional<Engagement> replaceEngagementIfLastUpdateMatched(Engagement replacement, String lastUpdate) {
+    public Optional<Engagement> updateEngagementIfLastUpdateMatched(Engagement toUpdate, String lastUpdate,
+            boolean skipLaunch) {
 
-        // create bson filter for last update
-        Bson filter = eq("lastUpdate", lastUpdate);
-        return Optional.ofNullable(this.mongoCollection().findOneAndReplace(filter, replacement));
+        // create the bson for filter and update
+        Bson filter = createFilterForEngagement(toUpdate, lastUpdate);
+        Bson update = createUpdateDocument(toUpdate, skipLaunch);
+
+        FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
+
+        return Optional.ofNullable(this.mongoCollection().findOneAndUpdate(filter, update, optionAfter));
+
+    }
+
+    /**
+     * Returns a {@link Bson} containing the filter to find {@link Engagement} with
+     * the corresponding customer name, project name, and last update timestamp.
+     * 
+     * @param engagement
+     * @param lastUpdate
+     * @return
+     */
+    private Bson createFilterForEngagement(Engagement engagement, String lastUpdate) {
+
+        return and(eq("customerName", engagement.getCustomerName()), eq("projectName", engagement.getProjectName()),
+                eq("lastUpdate", lastUpdate));
+
+    }
+
+    /**
+     * Returns a {@link Bson} containing the fields to be updated for a given
+     * {@link Engagement}.
+     * 
+     * @param engagement
+     * @param skipLaunch
+     * @return
+     */
+    private Bson createUpdateDocument(Engagement engagement, boolean skipLaunch) {
+
+        Bson updates = null;
+
+        // convert to map
+        TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {
+        };
+        Map<String, Object> fieldMap = objectMapper.convertValue(engagement, typeRef);
+
+        // remove values that should not be updated
+        IMMUTABLE_FIELDS.forEach(f -> {
+            if (!f.equals("launch") || skipLaunch) {
+                fieldMap.remove(f);
+            }
+        });
+
+        // add a set for each field in the update
+        for (String key : fieldMap.keySet()) {
+
+            Object value = fieldMap.get(key);
+            Bson update = set(key, value);
+
+            if (null == updates) {
+                updates = update;
+            } else {
+                updates = combine(updates, update);
+            }
+
+        }
+
+        return updates;
 
     }
 

--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -134,6 +134,9 @@ public class EngagementService {
                     HttpStatus.SC_CONFLICT);
         }
 
+        // send updated engagement to socket
+        sendEngagementEvent(jsonb.toJson(persisted));
+
         return optional.get();
 
     }

--- a/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
+++ b/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
@@ -131,6 +131,8 @@ public class GitSyncService {
 
                 // reset modified
                 engagement.setAction(null);
+                // reset last update
+                engagement.setLastUpdate(ZonedDateTime.now(ZoneId.of("Z")).toString());
 
             } catch (WebApplicationException e) {
                 // rest call returned and 400 or above http code

--- a/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
+++ b/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
@@ -131,8 +131,6 @@ public class GitSyncService {
 
                 // reset modified
                 engagement.setAction(null);
-                // reset last update
-                engagement.setLastUpdate(ZonedDateTime.now(ZoneId.of("Z")).toString());
 
             } catch (WebApplicationException e) {
                 // rest call returned and 400 or above http code

--- a/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 
@@ -296,22 +298,28 @@ public class EngagementResourceTest {
         String body = quarkusJsonb.toJson(engagement);
 
         // POST engagement
-        given()
+        Response response = given()
             .when()
                 .auth()
                 .oauth2(token)
                 .body(body)
                 .contentType(ContentType.JSON)
-                .post("/engagements")
-            .then()
-                .statusCode(201)
-                .body("customer_name", equalTo(engagement.getCustomerName()))
-                .body("project_name", equalTo(engagement.getProjectName()))
-                .body("project_id", nullValue());
+                .post("/engagements");
+
+        assertEquals(201, response.getStatusCode());
+
+        String responseBody = response.getBody().asString();
+        Engagement created = quarkusJsonb.fromJson(responseBody, Engagement.class);
+
+        assertEquals(engagement.getCustomerName(), created.getCustomerName());
+        assertEquals(engagement.getProjectName(), created.getProjectName());
+        assertNull(created.getProjectId());
+        assertNotNull(created.getLastUpdate());
 
         // update description
-        engagement.setDescription("updated");
-        body = quarkusJsonb.toJson(engagement);
+        created.setDescription("updated");
+
+        body = quarkusJsonb.toJson(created);
 
         given()
             .when()
@@ -322,10 +330,10 @@ public class EngagementResourceTest {
                 .put("/engagements/customers/" + engagement.getCustomerName() + "/projects/" + engagement.getProjectName())
             .then()
                 .statusCode(200)
-                .body("customer_name", equalTo(engagement.getCustomerName()))
-                .body("project_name", equalTo(engagement.getProjectName()))
+                .body("customer_name", equalTo(created.getCustomerName()))
+                .body("project_name", equalTo(created.getProjectName()))
                 .body("project_id", nullValue())
-                .body("description", equalTo(engagement.getDescription()));
+                .body("description", equalTo(created.getDescription()));
 
     }
 
@@ -774,18 +782,25 @@ public class EngagementResourceTest {
         String body = quarkusJsonb.toJson(engagement);
 
         // POST engagement
-        given()
+        Response response = given()
             .when()
                 .auth()
                 .oauth2(token)
                 .body(body)
                 .contentType(ContentType.JSON)
-                .post("/engagements")
-            .then()
-                .statusCode(201)
-                .body("customer_name", equalTo(engagement.getCustomerName()))
-                .body("project_name", equalTo(engagement.getProjectName()))
-                .body("project_id", nullValue());
+                .post("/engagements");
+
+        assertEquals(201, response.getStatusCode());
+
+        String responseBody = response.getBody().asString();
+        Engagement created = quarkusJsonb.fromJson(responseBody, Engagement.class);
+
+        assertEquals(engagement.getCustomerName(), created.getCustomerName());
+        assertEquals(engagement.getProjectName(), created.getProjectName());
+        assertNull(created.getProjectId());
+        assertNotNull(created.getLastUpdate());
+
+        body = quarkusJsonb.toJson(created);
 
         // Launch engagement
         given()

--- a/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
@@ -1158,6 +1158,62 @@ public class EngagementResourceTest {
 
     }
 
+    @Test
+    public void testHeadEngagementWithAuthAndRoleSuccess() throws Exception {
+
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
+
+        Engagement engagement = mockEngagement();
+        engagement.setDescription(SCENARIO.SUCCESS.getValue());
+
+        String body = quarkusJsonb.toJson(engagement);
+
+        // POST engagement
+        given()
+            .when()
+                .auth()
+                .oauth2(token)
+                .body(body)
+                .contentType(ContentType.JSON)
+                .post("/engagements")
+            .then()
+                .statusCode(201)
+                .body("customer_name", equalTo(engagement.getCustomerName()))
+                .body("project_name", equalTo(engagement.getProjectName()))
+                .body("project_id", nullValue());
+
+        // HEAD
+        given()
+            .when()
+                .auth()
+                .oauth2(token)
+                .head("/engagements/customers/" + engagement.getCustomerName() + "/projects/" + engagement.getProjectName())
+            .then()
+                .statusCode(200)
+                .header("last-update", notNullValue());
+
+    }
+
+    @Test
+    public void testHeadEngagementWithAuthAndRoleNptFound() throws Exception {
+
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
+
+        Engagement engagement = mockEngagement();
+
+        // HEAD
+        given()
+            .when()
+                .auth()
+                .oauth2(token)
+                .head("/engagements/customers/" + engagement.getCustomerName() + "/projects/" + engagement.getProjectName())
+            .then()
+                .statusCode(404);
+
+    }
+
     public Engagement mockEngagement() {
 
         Engagement engagement = Engagement.builder().customerName("TestCustomer").projectName("TestProject")

--- a/src/test/java/com/redhat/labs/omp/resources/GitSyncResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/GitSyncResourceTest.java
@@ -4,6 +4,8 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
@@ -50,19 +52,23 @@ public class GitSyncResourceTest {
         String body = quarkusJsonb.toJson(engagement);
 
         // POST engagement - create
-        given()
+        Response response = given()
             .when()
                 .auth()
                 .oauth2(token)
                 .body(body)
                 .contentType(ContentType.JSON)
-                .post("/engagements")
-            .then()
-                .statusCode(201)
-                .body("customer_name", equalTo(engagement.getCustomerName()))
-                .body("project_name", equalTo(engagement.getProjectName()))
-                .body("project_id", nullValue());
+                .post("/engagements");
 
+        assertEquals(201, response.getStatusCode());
+
+        String responseBody = response.getBody().asString();
+        Engagement created = quarkusJsonb.fromJson(responseBody, Engagement.class);
+
+        assertEquals(engagement.getCustomerName(), created.getCustomerName());
+        assertEquals(engagement.getProjectName(), created.getProjectName());
+        assertNull(created.getProjectId());
+        assertNotNull(created.getLastUpdate());
 
         // process created
         given()
@@ -78,8 +84,9 @@ public class GitSyncResourceTest {
         TimeUnit.SECONDS.sleep(1);
 
         // update description
-        engagement.setDescription("updated");
-        body = quarkusJsonb.toJson(engagement);
+        created.setDescription("updated");
+
+        body = quarkusJsonb.toJson(created);
 
         // PUT engagement - update
         given()
@@ -91,10 +98,10 @@ public class GitSyncResourceTest {
                 .put("/engagements/customers/" + engagement.getCustomerName() + "/projects/" + engagement.getProjectName())
             .then()
                 .statusCode(200)
-                .body("customer_name", equalTo(engagement.getCustomerName()))
-                .body("project_name", equalTo(engagement.getProjectName()))
+                .body("customer_name", equalTo(created.getCustomerName()))
+                .body("project_name", equalTo(created.getProjectName()))
                 .body("project_id", equalTo(1234))
-                .body("description", equalTo(engagement.getDescription()));
+                .body("description", equalTo(created.getDescription()));
 
         // process updated
         given()
@@ -120,23 +127,27 @@ public class GitSyncResourceTest {
         String body = quarkusJsonb.toJson(engagement);
 
         // POST engagement - create
-        given()
+        Response response = given()
             .when()
                 .auth()
                 .oauth2(token)
                 .body(body)
                 .contentType(ContentType.JSON)
-                .post("/engagements")
-            .then()
-                .statusCode(201)
-                .body("customer_name", equalTo(engagement.getCustomerName()))
-                .body("project_name", equalTo(engagement.getProjectName()))
-                .body("project_id", nullValue());
+                .post("/engagements");
 
+        assertEquals(201, response.getStatusCode());
+
+        String responseBody = response.getBody().asString();
+        Engagement created = quarkusJsonb.fromJson(responseBody, Engagement.class);
+
+        assertEquals(engagement.getCustomerName(), created.getCustomerName());
+        assertEquals(engagement.getProjectName(), created.getProjectName());
+        assertNull(created.getProjectId());
+        assertNotNull(created.getLastUpdate());
 
         // update description
-        engagement.setEngagementLeadName("mr.el");
-        body = quarkusJsonb.toJson(engagement);
+        created.setEngagementLeadName("mr.el");
+        body = quarkusJsonb.toJson(created);
 
         // PUT engagement - update
         given()
@@ -148,11 +159,11 @@ public class GitSyncResourceTest {
                 .put("/engagements/customers/" + engagement.getCustomerName() + "/projects/" + engagement.getProjectName())
             .then()
                 .statusCode(200)
-                .body("customer_name", equalTo(engagement.getCustomerName()))
-                .body("project_name", equalTo(engagement.getProjectName()))
+                .body("customer_name", equalTo(created.getCustomerName()))
+                .body("project_name", equalTo(created.getProjectName()))
                 .body("project_id", nullValue())
-                .body("description", equalTo(engagement.getDescription()))
-                .body("engagement_lead_name", equalTo(engagement.getEngagementLeadName()));
+                .body("description", equalTo(created.getDescription()))
+                .body("engagement_lead_name", equalTo(created.getEngagementLeadName()));
 
         // process updated
         given()


### PR DESCRIPTION
- added `lastUpdate` to engagement
- changed update to use `findOneAndUpdate` to prevent concurrent updates from overwriting data
- each create/update will set the `lastUpdate` on the engagement 
- update throws 409 status if the `engagement` has been modified by another call
- added HEAD api for an engagement - returns `last-update` attribute in headers if engagement exists