### PR TITLE
fix hook get by path

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/GitlabProject.java
+++ b/src/main/java/com/redhat/labs/omp/model/GitlabProject.java
@@ -10,16 +10,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GitlabProject {
-    private static final String REGEX = "(.*) \\/ (.*) \\/ (.*) \\/ iac";
+    private static final String NAME_REGEX = "(.*) \\/ (.*) \\/ (.*) \\/ iac";
+    private static final String PATH_REGEX = "(.*)\\/(.*)\\/(.*)\\/iac";
 
     private String pathWithNamespace;
     private String nameWithNamespace;
     
     public String getCustomerNameFromName() {
-        return nameWithNamespace.replaceAll(REGEX, "$2");
+    	if(nameWithNamespace == null) {
+    		return pathWithNamespace.replaceAll(PATH_REGEX, "$2");
+    	}
+        return nameWithNamespace.replaceAll(NAME_REGEX, "$2");
     }
     
     public String getEngagementNameFromName() {
-        return nameWithNamespace.replaceAll(REGEX, "$3");
+    	if(nameWithNamespace == null) {
+    		return pathWithNamespace.replaceAll(PATH_REGEX, "$3");
+    	}
+        return nameWithNamespace.replaceAll(NAME_REGEX, "$3");
     }
 }


### PR DESCRIPTION
Fixes issue where status hook errors with null pointer. Apparently, the name with namespace does not get sent with the webhook event payload. This uses the path instead as it did before. Because the path may not always be correct (special characters can be removed from the path but not the name) a fallback needs to be in place which there is. The fallback sends the path to the git-api to get the engagement by path.