### PR TITLE
Expose Status Service Version through Backend

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/status/VersionManifestV1.java
+++ b/src/main/java/com/redhat/labs/omp/model/status/VersionManifestV1.java
@@ -1,0 +1,19 @@
+package com.redhat.labs.omp.model.status;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VersionManifestV1 {
+
+    private VersionV1 mainVersion;
+    private List<VersionV1> componentVersions;
+
+}

--- a/src/main/java/com/redhat/labs/omp/model/status/VersionV1.java
+++ b/src/main/java/com/redhat/labs/omp/model/status/VersionV1.java
@@ -1,0 +1,17 @@
+package com.redhat.labs.omp.model.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VersionV1 {
+
+    private String name;
+    private String value;
+
+}

--- a/src/main/java/com/redhat/labs/omp/resource/VersionResource.java
+++ b/src/main/java/com/redhat/labs/omp/resource/VersionResource.java
@@ -12,7 +12,9 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import com.redhat.labs.omp.model.Version;
 import com.redhat.labs.omp.model.VersionManifest;
+import com.redhat.labs.omp.model.status.VersionManifestV1;
 import com.redhat.labs.omp.service.VersionService;
 
 /**
@@ -21,7 +23,7 @@ import com.redhat.labs.omp.service.VersionService;
  *
  */
 @RequestScoped
-@Path("/api/v1/version")
+@Path("/api")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class VersionResource {
@@ -29,13 +31,34 @@ public class VersionResource {
     VersionService versionService;
     
     @GET
-    @Timed(name="versionResourceTimer")
-    @Counted(name="versionResourceCounter")
+    @Path("/v1/version")
+    @Timed(name="versionResourceV1Timer")
+    @Counted(name="versionResourceV1Counter")
     @PermitAll
-    public VersionManifest getVersion() {
+    @Deprecated
+    public VersionManifest getVersionV1() {
         VersionManifest vm = versionService.getVersionManifest();
         vm.addContainer(versionService.getGitApiVersion());
 
         return vm;
     }
+
+    @GET
+    @Path("/v2/version")
+    @Timed(name="versionResourceV2Timer")
+    @Counted(name="versionResourceV2Counter")
+    @PermitAll
+    public Version getBackendVersion() {
+        return versionService.getBackendVersion();
+    }
+
+    @GET
+    @PermitAll
+    @Path("/v1/version/manifest")
+    @Timed(name="versionManifestResourceTimer")
+    @Counted(name="versionManifestResourceCounter")
+    public VersionManifestV1 getVersionDetailSummary() {
+        return versionService.getVersionManifestV1FromStatusClient();
+    }
+
 }

--- a/src/main/java/com/redhat/labs/omp/rest/client/LodeStarStatusApiClient.java
+++ b/src/main/java/com/redhat/labs/omp/rest/client/LodeStarStatusApiClient.java
@@ -1,0 +1,19 @@
+package com.redhat.labs.omp.rest.client;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import com.redhat.labs.omp.model.status.VersionManifestV1;
+
+@RegisterRestClient(configKey = "lodestar.status.api")
+public interface LodeStarStatusApiClient {
+
+    @GET
+    @Produces("application/json")
+    @Path("/api/v1/version/manifest")
+    public VersionManifestV1 getVersionManifestV1();
+
+}

--- a/src/main/java/com/redhat/labs/omp/service/VersionService.java
+++ b/src/main/java/com/redhat/labs/omp/service/VersionService.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,23 +13,73 @@ import org.slf4j.LoggerFactory;
 import com.redhat.labs.omp.config.VersionManifestConfig;
 import com.redhat.labs.omp.model.Version;
 import com.redhat.labs.omp.model.VersionManifest;
+import com.redhat.labs.omp.model.status.VersionManifestV1;
+import com.redhat.labs.omp.rest.client.LodeStarStatusApiClient;
 import com.redhat.labs.omp.rest.client.OMPGitLabAPIService;
 
 @ApplicationScoped
 public class VersionService {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(VersionService.class);
+
+    @ConfigProperty(name = "git.commit")
+    String gitCommit;
+
+    @ConfigProperty(name = "git.tag")
+    String gitTag;
 
     @RestClient
     @Inject
     OMPGitLabAPIService gitApiService;
 
     @Inject
+    @RestClient
+    LodeStarStatusApiClient statusApiClient;
+
+    @Inject
     VersionManifestConfig versionManifestConfig;
 
+    /**
+     * Returns the configured {@link Version} containing the git commit and git tag.
+     * 
+     * @return
+     */
+    public Version getBackendVersion() {
+        return Version.builder().gitCommit(gitCommit).gitTag(gitTag).build();
+    }
+
+    /**
+     * Returns the {@link VersionManifestV1} from the LodeStar Status Service.
+     * 
+     * @return
+     */
+    public VersionManifestV1 getVersionManifestV1FromStatusClient() {
+        return statusApiClient.getVersionManifestV1();
+    }
+
+    /**
+     * Returns the {@link VersionManifest} from the configured ConfigMap. This
+     * method is {@link Deprecated}.
+     * 
+     * The version manifest should be retreived using
+     * getVersionManifestV1FromStatusClient().
+     * 
+     * @return
+     */
+    @Deprecated
     public VersionManifest getVersionManifest() {
         return versionManifestConfig.getVersionData();
     }
 
+    /**
+     * Retrieves the Version of the Git API using the service's version API. This
+     * method is {@link Deprecated}.
+     * 
+     * The LodeStar Status API should be used to return the version of all LodeStar
+     * components.
+     * 
+     * @return
+     */
     public Version getGitApiVersion() {
         Version version;
 
@@ -39,8 +90,8 @@ public class VersionService {
             version = Version.builder().gitTag("error-getting-version").gitCommit("error-getting-commit").build();
         }
         version.setApplication("omp-git-api-container");
-        
-        if(version.getGitTag().equals("master") || version.getGitTag().equals("latest")) {
+
+        if (version.getGitTag().equals("master") || version.getGitTag().equals("latest")) {
             version.setVersion(version.getGitTag() + "-" + version.getGitCommit());
         } else {
             version.setVersion(version.getGitTag());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,6 +55,8 @@ quarkus.mongodb.connection-string=mongodb://${mongo.user}:${mongo.password}@${mo
 
 # git api
 omp.gitlab.api/mp-rest/url=${OMP_GITLAB_API_URL:http://omp-git-api:8080}
+# status api
+lodestar.status.api/mp-rest/url=${LODESTAR_STATUS_API_URL:http://lodestar-status:8080}
 
 webhook.token=${WEBHOOK_TOKEN:t}
 cleanup.token=${CLEANUP_TOKEN:OFF}

--- a/src/test/java/com/redhat/labs/omp/resources/VersionResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/VersionResourceTest.java
@@ -2,6 +2,7 @@ package com.redhat.labs.omp.resources;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,5 +26,35 @@ public class VersionResourceTest {
             .body("containers.version",hasItem("master-abcdef"))
             .body("containers.version", hasItem("v1.1"));
     }   
+
+    @Test
+    public void testValidResourceVersion2() {
+
+        given()
+        .when()
+            .contentType(ContentType.JSON)
+            .get("/api/v2/version")
+        .then()
+            .statusCode(200)
+            .body("git_commit", is("abcdef"))
+            .body("git_tag", is("master"));
+
+    }
+
+    @Test
+    public void testValidResourceVersionManifest() {
+
+        given()
+        .when()
+            .contentType(ContentType.JSON)
+            .get("/api/v1/version/manifest")
+        .then()
+            .statusCode(200)
+            .body("main_version.name",is("ball"))
+            .body("main_version.value", is("v2.0"))
+            .body("component_versions.name", hasItem("launcher"))
+            .body("component_versions.value", hasItem("v1.1"));
+
+    }
+
 }
-    

--- a/src/test/java/com/redhat/labs/omp/rest/client/MockLodeStarStatusApiClient.java
+++ b/src/test/java/com/redhat/labs/omp/rest/client/MockLodeStarStatusApiClient.java
@@ -1,0 +1,30 @@
+package com.redhat.labs.omp.rest.client;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.json.bind.Jsonb;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import com.redhat.labs.omp.model.status.VersionManifestV1;
+import com.redhat.labs.utils.ResourceLoader;
+
+import io.quarkus.test.Mock;
+
+@Mock
+@RestClient
+@ApplicationScoped
+public class MockLodeStarStatusApiClient implements LodeStarStatusApiClient {
+
+    @Inject
+    Jsonb jsonb;
+
+    @Override
+    public VersionManifestV1 getVersionManifestV1() {
+
+        String json = ResourceLoader.load("status-service/version-manifest.yaml");
+        return jsonb.fromJson(json, VersionManifestV1.class);
+
+    }
+
+}

--- a/src/test/resources/status-service/version-manifest.yaml
+++ b/src/test/resources/status-service/version-manifest.yaml
@@ -1,0 +1,12 @@
+{
+    "component_versions": [
+        {
+            "name": "launcher",
+            "value": "v1.1"
+        }
+    ],
+    "main_version": {
+        "name": "ball",
+        "value": "v2.0"
+    }
+}


### PR DESCRIPTION
Adding endpoints to expose the LodeStar Status Version API through the LodeStar Backend:

- `GET /api/v1/version` retains existing functionality as to not break the current fe
- `GET /api/v2/version` returns the `git_commit` and `git_tag` for the deployed `lodestar-backend`
- `GET /api/v1/version/manifest` returns the manifest from the `lodestar-status -> GET /api/v1/version/manifest`