### PR TITLE
last update should not be updated on status update

### DIFF
--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -170,9 +170,6 @@ public class EngagementService {
         List<Commit> commits = gitApi.getCommits(hook.getCustomerName(), hook.getEngagementName());
         persisted.setCommits(commits);
 
-        // set last update
-        persisted.setLastUpdate(getZuluTimeAsString());
-
         // update in db
         repository.update(persisted);
 


### PR DESCRIPTION
Since the status and commit history are coming from gitlab and are not editable from the front end, the `last_update` attribute should not be modified when the status/commit data is updated in the database.

The FE user will get that status when the `engagement` is refreshed.