### PR TITLE
Component Status API

### DIFF
--- a/deployment/templates/deploymentconfig.yaml
+++ b/deployment/templates/deploymentconfig.yaml
@@ -33,6 +33,24 @@ spec:
         env:
         - name: OMP_BACKEND_GIT_TAG
           value: {{ .Values.imageTag }}
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+            scheme: HTTP
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8080
+            scheme: HTTP
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
         image: {{ .Values.name }}:{{ .Values.imageTag }}
         imagePullPolicy: Always
         name: {{ .Values.name }}

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/redhat/labs/omp/health/BackendLivenessCheck.java
+++ b/src/main/java/com/redhat/labs/omp/health/BackendLivenessCheck.java
@@ -1,0 +1,20 @@
+package com.redhat.labs.omp.health;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+@Liveness
+@ApplicationScoped
+public class BackendLivenessCheck implements HealthCheck {
+
+    private static final String BACKEND_LIVENESS = "BACKEND LIVENESS";
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.up(BACKEND_LIVENESS);
+    }
+
+}

--- a/src/main/java/com/redhat/labs/omp/health/GitApiHealthCheck.java
+++ b/src/main/java/com/redhat/labs/omp/health/GitApiHealthCheck.java
@@ -1,0 +1,32 @@
+package com.redhat.labs.omp.health;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+import com.redhat.labs.omp.rest.client.OMPGitLabAPIService;
+
+@Readiness
+@ApplicationScoped
+public class GitApiHealthCheck implements HealthCheck {
+
+    private static final String NAME = "Git API";
+    @Inject
+    OMPGitLabAPIService service;
+
+    @Override
+    public HealthCheckResponse call() {
+
+        try {
+            service.getVersion();
+            return HealthCheckResponse.up(NAME);
+        } catch (Exception e) {
+            return HealthCheckResponse.down(NAME);
+        }
+
+    }
+
+}

--- a/src/main/java/com/redhat/labs/omp/health/GitApiHealthCheck.java
+++ b/src/main/java/com/redhat/labs/omp/health/GitApiHealthCheck.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import com.redhat.labs.omp.rest.client.OMPGitLabAPIService;
 
@@ -14,7 +15,9 @@ import com.redhat.labs.omp.rest.client.OMPGitLabAPIService;
 public class GitApiHealthCheck implements HealthCheck {
 
     private static final String NAME = "Git API";
+
     @Inject
+    @RestClient
     OMPGitLabAPIService service;
 
     @Override

--- a/src/main/java/com/redhat/labs/omp/resource/StatusResource.java
+++ b/src/main/java/com/redhat/labs/omp/resource/StatusResource.java
@@ -4,6 +4,7 @@ import javax.annotation.security.PermitAll;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -21,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.redhat.labs.omp.model.Hook;
+import com.redhat.labs.omp.rest.client.LodeStarStatusApiClient;
 import com.redhat.labs.omp.rest.client.OMPGitLabAPIService;
 import com.redhat.labs.omp.service.EngagementService;
 
@@ -40,6 +42,10 @@ public class StatusResource {
     @Inject
     @RestClient
     OMPGitLabAPIService gitApi;
+
+    @Inject
+    @RestClient
+    LodeStarStatusApiClient statusClient;
     
     @Inject
     EngagementService engagementService;
@@ -86,4 +92,14 @@ public class StatusResource {
 
         return Response.ok().build();
     }
+
+    @GET
+    @PermitAll
+    @APIResponses(value = { 
+            @APIResponse(responseCode = "200", description = "Component Status has been returned.") })
+    @Operation(summary = "Returns status of all configured components.")
+    public Response getComponentStatus() {
+        return statusClient.getComponentStatus();
+    }
+
 }

--- a/src/main/java/com/redhat/labs/omp/rest/client/LodeStarStatusApiClient.java
+++ b/src/main/java/com/redhat/labs/omp/rest/client/LodeStarStatusApiClient.java
@@ -1,13 +1,19 @@
 package com.redhat.labs.omp.rest.client;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import com.redhat.labs.omp.model.status.VersionManifestV1;
 
+@ApplicationScoped
 @RegisterRestClient(configKey = "lodestar.status.api")
 public interface LodeStarStatusApiClient {
 
@@ -15,5 +21,14 @@ public interface LodeStarStatusApiClient {
     @Produces("application/json")
     @Path("/api/v1/version/manifest")
     public VersionManifestV1 getVersionManifestV1();
+
+    @GET
+    @Produces("application/json")
+    @Path("/api/v1/status")
+    @APIResponses(value = { 
+            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "200", description = "Configuration file data has been returned.") })
+    @Operation(summary = "Returns configuration file data from git.")
+    public Response getComponentStatus();
 
 }

--- a/src/main/java/com/redhat/labs/omp/rest/client/LodeStarStatusApiClient.java
+++ b/src/main/java/com/redhat/labs/omp/rest/client/LodeStarStatusApiClient.java
@@ -6,9 +6,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
-import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import com.redhat.labs.omp.model.status.VersionManifestV1;
@@ -23,12 +20,8 @@ public interface LodeStarStatusApiClient {
     public VersionManifestV1 getVersionManifestV1();
 
     @GET
-    @Produces("application/json")
     @Path("/api/v1/status")
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
-            @APIResponse(responseCode = "200", description = "Configuration file data has been returned.") })
-    @Operation(summary = "Returns configuration file data from git.")
+    @Produces("application/json")
     public Response getComponentStatus();
 
 }

--- a/src/test/java/com/redhat/labs/omp/rest/client/MockLodeStarStatusApiClient.java
+++ b/src/test/java/com/redhat/labs/omp/rest/client/MockLodeStarStatusApiClient.java
@@ -3,6 +3,7 @@ package com.redhat.labs.omp.rest.client;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
+import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -25,6 +26,12 @@ public class MockLodeStarStatusApiClient implements LodeStarStatusApiClient {
         String json = ResourceLoader.load("status-service/version-manifest.yaml");
         return jsonb.fromJson(json, VersionManifestV1.class);
 
+    }
+
+    @Override
+    public Response getComponentStatus() {
+        // TODO Auto-generated method stub
+        return null;
     }
 
 }


### PR DESCRIPTION
- added `GET /status`
  - calls the status service `GET /api/v1/status` and returns the response.
- added liveness and readiness checks to `deploymentconfig`
- added readiness check for `git-api`