### PR TITLE
Add Commit Message to Engagement

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
@@ -95,6 +95,8 @@ public class Engagement extends PanacheMongoEntityBase {
     private List<Category> categories;
 
     private List<Artifact> artifacts;
+
+    @JsonbProperty("commit_message")
     private String commitMessage;
 
     @JsonbTransient

--- a/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
@@ -95,6 +95,7 @@ public class Engagement extends PanacheMongoEntityBase {
     private List<Category> categories;
 
     private List<Artifact> artifacts;
+    private String commitMessage;
 
     @JsonbTransient
     private FileAction action;

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -140,7 +140,7 @@ public class EngagementService {
             String existing = persisted.getCommitMessage();
 
             // if another message on current request, append to existing message
-            String message = (null != engagement.getCommitMessage()) ? existing
+            String message = (null == engagement.getCommitMessage()) ? existing
                     : new StringBuilder().append("\n\n").append(existing).toString();
 
             // set the message on the engagement before persisting
@@ -148,8 +148,6 @@ public class EngagementService {
 
             LOGGER.debug("set commit message to - {}", message);
 
-        } else {
-            LOGGER.debug("no persisted commit message, using {}", engagement.getCommitMessage());
         }
 
         // save the current last updated value and reset

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -135,13 +135,13 @@ public class EngagementService {
         if (null != persisted.getCommitMessage()) {
 
             LOGGER.debug("persisted commit message found. {}", persisted.getCommitMessage());
-            
+
             // get existing message
             String existing = persisted.getCommitMessage();
 
             // if another message on current request, append to existing message
             String message = (null == engagement.getCommitMessage()) ? existing
-                    : new StringBuilder().append("\n\n").append(existing).toString();
+                    : new StringBuilder(existing).append("\n\n").append(engagement.getCommitMessage()).toString();
 
             // set the message on the engagement before persisting
             engagement.setCommitMessage(message);

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -131,6 +131,21 @@ public class EngagementService {
         // mark as updated, if action not already assigned
         engagement.setAction((null != persisted.getAction()) ? persisted.getAction() : FileAction.update);
 
+        // aggregate commit messages if already set
+        if (null != persisted.getCommitMessage()) {
+
+            // get existing message
+            String existing = persisted.getCommitMessage();
+
+            // if another message on current request, append to existing message
+            String message = (null != engagement.getCommitMessage()) ? existing
+                    : new StringBuilder().append("\n\n").append(existing).toString();
+
+            // set the message on the engagement before persisting
+            engagement.setCommitMessage(message);
+
+        }
+
         // save the current last updated value and reset
         String currentLastUpdated = engagement.getLastUpdate();
         engagement.setLastUpdate(getZuluTimeAsString());
@@ -152,7 +167,6 @@ public class EngagementService {
         return optional.get();
 
     }
-
 
     // Status comes from gitlab so it does not need to to be sync'd
     public Engagement updateStatusAndCommits(Hook hook) {
@@ -226,14 +240,13 @@ public class EngagementService {
      */
     public List<Engagement> getAll(String categories) {
 
-        if(null == categories || categories.isBlank()) {
+        if (null == categories || categories.isBlank()) {
             return repository.listAll();
         }
 
-       return 
-               Arrays.stream(categories.split(","))
-                   .flatMap(category -> repository.findEngagementsByCategory(category, false).stream())
-                   .collect(Collectors.toList());
+        return Arrays.stream(categories.split(","))
+                .flatMap(category -> repository.findEngagementsByCategory(category, false).stream())
+                .collect(Collectors.toList());
 
     }
 
@@ -279,15 +292,16 @@ public class EngagementService {
     }
 
     /**
-     * Returns a {@link List} of {@link Category} that match the provided {@link String}.  Returns all
-     * {@link Category} if no match {@link String} provided.
+     * Returns a {@link List} of {@link Category} that match the provided
+     * {@link String}. Returns all {@link Category} if no match {@link String}
+     * provided.
      * 
      * @param optionalMatch
      * @return
      */
     public List<Category> getCategories(String match) {
 
-        if(null == match || match.isBlank()) {
+        if (null == match || match.isBlank()) {
             return repository.findAllCategoryWithCounts();
         }
 
@@ -296,15 +310,15 @@ public class EngagementService {
     }
 
     /**
-     * Returns a {@link List} of Artifact Types as {@link String} that match the provided 
-     * input {@link String}.  Otherwise, all Types are returned.
+     * Returns a {@link List} of Artifact Types as {@link String} that match the
+     * provided input {@link String}. Otherwise, all Types are returned.
      * 
      * @param match
      * @return
      */
     public List<String> getArtifactTypes(String match) {
 
-        if(null == match || match.isBlank()) {
+        if (null == match || match.isBlank()) {
             return repository.findAllArtifactTypes();
         }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -134,6 +134,8 @@ public class EngagementService {
         // aggregate commit messages if already set
         if (null != persisted.getCommitMessage()) {
 
+            LOGGER.debug("persisted commit message found. {}", persisted.getCommitMessage());
+            
             // get existing message
             String existing = persisted.getCommitMessage();
 
@@ -144,6 +146,10 @@ public class EngagementService {
             // set the message on the engagement before persisting
             engagement.setCommitMessage(message);
 
+            LOGGER.debug("set commit message to - {}", message);
+
+        } else {
+            LOGGER.debug("no persisted commit message, using {}", engagement.getCommitMessage());
         }
 
         // save the current last updated value and reset

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -134,8 +134,6 @@ public class EngagementService {
         // aggregate commit messages if already set
         if (null != persisted.getCommitMessage()) {
 
-            LOGGER.debug("persisted commit message found. {}", persisted.getCommitMessage());
-
             // get existing message
             String existing = persisted.getCommitMessage();
 
@@ -145,8 +143,6 @@ public class EngagementService {
 
             // set the message on the engagement before persisting
             engagement.setCommitMessage(message);
-
-            LOGGER.debug("set commit message to - {}", message);
 
         }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/GitSyncService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/GitSyncService.java
@@ -99,6 +99,7 @@ public class GitSyncService {
 
                 // reset modified
                 engagement.setAction(null);
+                engagement.setCommitMessage(null);
 
             } catch (WebApplicationException e) {
                 // rest call returned and 400 or above http code


### PR DESCRIPTION
- `commit_message` attribute added to engagement model
  - if specified, it will be used in the git-api to set the commit message when an engagement is created/updated.