### PR TITLE
Bugfix: Git Sync Can Cause Subsequent Modifications to be Reverted

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/exception/mapper/LodeStarGitLabAPIServiceResponseMapper.java
+++ b/src/main/java/com/redhat/labs/lodestar/exception/mapper/LodeStarGitLabAPIServiceResponseMapper.java
@@ -1,0 +1,32 @@
+package com.redhat.labs.lodestar.exception.mapper;
+
+import java.io.ByteArrayInputStream;
+
+import javax.annotation.Priority;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+@Priority(4000)
+public class LodeStarGitLabAPIServiceResponseMapper implements 
+             ResponseExceptionMapper<RuntimeException> {
+  @Override
+  public RuntimeException toThrowable(Response response) {
+    int status = response.getStatus();
+
+    String msg = getBody(response);
+
+    return new WebApplicationException(msg, status);
+
+  }
+
+  private String getBody(Response response) {
+      ByteArrayInputStream is = (ByteArrayInputStream) response.getEntity();
+      byte[] bytes = new byte[is.available()];
+      is.read(bytes,0,is.available());
+      String body = new String(bytes);
+      return body;
+    }
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -34,6 +34,7 @@ import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.Sorts;
 import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
+import com.redhat.labs.lodestar.model.CreationDetails;
 import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.FileAction;
 
@@ -248,6 +249,44 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
                 updates = combine(updates, update);
             }
 
+        }
+
+        return updates;
+
+    }
+
+    public Optional<Engagement> updateEngagement(String customerName, String projectName,
+            Optional<CreationDetails> creationDetails, Optional<Integer> projectId, boolean resetFlags) {
+
+        // filter on customer/project name only
+        Bson filter = and(eq("customerName", customerName), eq("projectName", projectName));
+
+        // update only required fields
+        Bson update = updateGitSyncFields(creationDetails, projectId, resetFlags);
+
+        // make sure value returned is the updated document
+        FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
+
+        return Optional.ofNullable(this.mongoCollection().findOneAndUpdate(filter, update, optionAfter));
+
+    }
+
+    private Bson updateGitSyncFields(Optional<CreationDetails> creationDetails, Optional<Integer> projectId,
+            boolean resetFlags) {
+
+        Bson updates = new Document();
+
+        if (creationDetails.isPresent()) {
+            updates = combine(updates, set("creationDetails", creationDetails.get()));
+        }
+
+        if (projectId.isPresent()) {
+            updates = combine(updates, set("projectId", projectId.get()));
+        }
+
+        if (resetFlags) {
+            updates = combine(updates, set("action", null));
+            updates = combine(updates, set("commitMessage", null));
         }
 
         return updates;

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -11,6 +11,7 @@ import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.set;
+import static com.mongodb.client.model.Updates.unset;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -285,8 +286,8 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
         }
 
         if (resetFlags) {
-            updates = combine(updates, set("action", null));
-            updates = combine(updates, set("commitMessage", null));
+            updates = combine(updates, unset("action"));
+            updates = combine(updates, unset("commitMessage"));
         }
 
         return updates;

--- a/src/main/java/com/redhat/labs/lodestar/rest/client/LodeStarGitLabAPIService.java
+++ b/src/main/java/com/redhat/labs/lodestar/rest/client/LodeStarGitLabAPIService.java
@@ -10,15 +10,18 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
+import com.redhat.labs.lodestar.exception.mapper.LodeStarGitLabAPIServiceResponseMapper;
 import com.redhat.labs.lodestar.model.Commit;
 import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.Status;
 import com.redhat.labs.lodestar.model.Version;
 
 @RegisterRestClient(configKey = "lodestar.gitlab.api")
+@RegisterProvider(value = LodeStarGitLabAPIServiceResponseMapper.class, priority = 50)
 public interface LodeStarGitLabAPIService {
 
     @GET

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -354,7 +354,7 @@ public class EngagementService {
                 }
 
                 // reset action and commit message only if it has not changed since last push to git;
-                // otherwise, keep values to all new changes to be pushed to git
+                // otherwise, keep values to allow new changes to be pushed to git
                 if(e.getLastUpdate().equals(persisted.getLastUpdate())) {
 
                     persisted.setAction(null);

--- a/src/main/java/com/redhat/labs/lodestar/service/GitSyncService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/GitSyncService.java
@@ -97,10 +97,6 @@ public class GitSyncService {
                     updateIdFromResponse(engagement, response);
                 }
 
-                // reset modified
-                engagement.setAction(null);
-                engagement.setCommitMessage(null);
-
             } catch (WebApplicationException e) {
                 // rest call returned and 400 or above http code
                 LOGGER.error(


### PR DESCRIPTION
Error Flow:

Engagement updated --> Git Sends modified Engagement to Git API --> Engagement Updated Again before Git API response processed --> Git Sync updates the Engagement in the Database with the prior (now stale) data 

The issue is that when the response from the Git API is returned, the sync sends a request to update the engagement so that the modified flags are cleared.  This works fine if the engagement has not be modified during the sync processing.  If it has been modified there is the potential of replacing the current engagement with what is now in Git.  This then will lose any changes that were waiting to be pushed to Git.