### PR TITLE
Sonar - Reliability and Security Fixes

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/model/EngagementUser.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/EngagementUser.java
@@ -34,7 +34,7 @@ public class EngagementUser {
         if (getClass() != obj.getClass())
             return false;
         EngagementUser other = (EngagementUser) obj;
-        if (email == null && other.email != null) {
+        if ((email == null && other.email != null) || (email != null && other.email == null)) {
             return false;
         }
         return email.equals(other.email);

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -44,7 +44,7 @@ import io.quarkus.mongodb.panache.PanacheMongoRepository;
 @ApplicationScoped
 public class EngagementRepository implements PanacheMongoRepository<Engagement> {
 
-    public static final List<String> IMMUTABLE_FIELDS = new ArrayList<>(
+    private static final List<String> IMMUTABLE_FIELDS = new ArrayList<>(
             Arrays.asList("uuid", "mongoId", "projectId", "creationDetails", "status", "commits", "launch"));
 
     private ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/com/redhat/labs/lodestar/resources/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resources/EngagementResourceTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 
-import org.jose4j.json.internal.json_simple.JSONArray;
 import org.jose4j.json.internal.json_simple.JSONObject;
 import org.jose4j.json.internal.json_simple.parser.JSONParser;
 import org.jose4j.json.internal.json_simple.parser.ParseException;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
 import com.redhat.labs.lodestar.model.Engagement;
-import com.redhat.labs.lodestar.model.EngagementUser;
 import com.redhat.labs.lodestar.rest.client.MockLodeStarGitLabAPIService.SCENARIO;
 import com.redhat.labs.lodestar.utils.EmbeddedMongoTest;
 import com.redhat.labs.lodestar.utils.TokenUtils;


### PR DESCRIPTION
- Equals method could throw null pointer if called from the API level.  Shouldn't be possible through the UI
- Repository Field should not be public
- Removed unused import from test