### PR TITLE
User Reset Implementation

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/model/EngagementUser.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/EngagementUser.java
@@ -24,6 +24,8 @@ public class EngagementUser {
     private String email;
     @NotBlank
     private String role;
+    private String uuid;
+    private boolean reset;
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -188,7 +188,7 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
      * @return
      */
     public Optional<Engagement> updateEngagementIfLastUpdateMatched(Engagement toUpdate, String lastUpdate,
-            boolean skipLaunch) {
+            Boolean skipLaunch) {
 
         // create the bson for filter and update
         Bson filter = createFilterForEngagement(toUpdate, lastUpdate);

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -11,7 +11,6 @@ import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.set;
-import static com.mongodb.client.model.Updates.unset;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,9 +34,7 @@ import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.Sorts;
 import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
-import com.redhat.labs.lodestar.model.CreationDetails;
 import com.redhat.labs.lodestar.model.Engagement;
-import com.redhat.labs.lodestar.model.FileAction;
 
 import io.quarkus.mongodb.panache.PanacheMongoRepository;
 
@@ -57,16 +54,8 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
         return find("customerName=?1 and projectName=?2", customerName, projectName).firstResultOptional();
     }
 
-    public List<Engagement> findByModifiedAndAction(FileAction action) {
-        return find("action", action).list();
-    }
-
     public List<Engagement> findByModified() {
         return find("action is not null").list();
-    }
-
-    public List<Engagement> findByNullUuid() {
-        return find("uuid is null").list();
     }
 
     /**
@@ -251,61 +240,6 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
         }
 
         return updates;
-
-    }
-
-    public Optional<Engagement> updateEngagement(String customerName, String projectName,
-            Optional<CreationDetails> creationDetails, Optional<Integer> projectId, boolean resetFlags) {
-
-        // filter on customer/project name only
-        Bson filter = and(eq("customerName", customerName), eq("projectName", projectName));
-
-        // update only required fields
-        Bson update = updateGitSyncFields(creationDetails, projectId, resetFlags);
-
-        // make sure value returned is the updated document
-        FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
-
-        return Optional.ofNullable(this.mongoCollection().findOneAndUpdate(filter, update, optionAfter));
-
-    }
-
-    private Bson updateGitSyncFields(Optional<CreationDetails> creationDetails, Optional<Integer> projectId,
-            boolean resetFlags) {
-
-        Bson updates = new Document();
-
-        if (creationDetails.isPresent()) {
-            updates = combine(updates, set("creationDetails", creationDetails.get()));
-        }
-
-        if (projectId.isPresent()) {
-            updates = combine(updates, set("projectId", projectId.get()));
-        }
-
-        if (resetFlags) {
-            updates = combine(updates, unset("action"));
-            updates = combine(updates, unset("commitMessage"));
-        }
-
-        return updates;
-
-    }
-
-    public Optional<Engagement> updateUuidForEngagement(String customerName, String projectName, String uuid,
-            String action, String authorName, String authorEmail) {
-
-        // filter on customer/project name only
-        Bson filter = and(eq("customerName", customerName), eq("projectName", projectName));
-        // update uuid and action
-        Bson update = combine(set("uuid", uuid), set("action", action));
-        update = combine(update, set("lastUpdateByName", authorName));
-        update = combine(update, set("lastUpdateByEmail", authorEmail));
-
-        // make sure value returned is the updated document
-        FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
-
-        return Optional.ofNullable(this.mongoCollection().findOneAndUpdate(filter, update, optionAfter));
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/resources/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resources/EngagementResourceTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 
-import org.jose4j.json.internal.json_simple.JSONArray;
 import org.jose4j.json.internal.json_simple.JSONObject;
 import org.jose4j.json.internal.json_simple.parser.JSONParser;
 import org.jose4j.json.internal.json_simple.parser.ParseException;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
 import com.redhat.labs.lodestar.model.Engagement;
-import com.redhat.labs.lodestar.model.EngagementUser;
 import com.redhat.labs.lodestar.rest.client.MockLodeStarGitLabAPIService.SCENARIO;
 import com.redhat.labs.lodestar.utils.EmbeddedMongoTest;
 import com.redhat.labs.lodestar.utils.TokenUtils;

--- a/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
@@ -1,47 +1,229 @@
 package com.redhat.labs.lodestar.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.collections.Sets;
 
 import com.redhat.labs.lodestar.model.Engagement;
+import com.redhat.labs.lodestar.model.EngagementUser;
 import com.redhat.labs.lodestar.model.GitlabProject;
 import com.redhat.labs.lodestar.model.Hook;
 import com.redhat.labs.lodestar.model.Launch;
+import com.redhat.labs.lodestar.repository.EngagementRepository;
 import com.redhat.labs.lodestar.utils.EmbeddedMongoTest;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
 
 @EmbeddedMongoTest
 @QuarkusTest
 class EngagementServiceTest {
 
-	
-	@Inject
-	EngagementService engagementService;
-	
-	@Test void testUpdateStatusInvalidProject() {
-		Hook hook = Hook.builder().project(GitlabProject.builder().pathWithNamespace("/nope/nada/iac").nameWithNamespace("/ nope / nada / iac").build()).build();
-		
-		Exception ex = assertThrows(WebApplicationException.class, ()-> {
-			engagementService.updateStatusAndCommits(hook);
-		});
-		
-		assertEquals("no engagement found. unable to update from hook.", ex.getMessage());
-	}
-	
-	@Test void testAlreadyLaunched() {
-		Engagement engagement = Engagement.builder().launch(Launch.builder().build()).build();
-		
-		Exception ex = assertThrows(WebApplicationException.class, ()-> {
-			engagementService.launch(engagement);
-		});
-		
-		assertEquals("engagement has already been launched.", ex.getMessage());
-	}
-	
+    @InjectMock
+    EngagementRepository repository;
+
+    @Inject
+    EngagementService engagementService;
+
+    @Test
+    void testUpdateStatusInvalidProject() {
+        Hook hook = Hook.builder().project(GitlabProject.builder().pathWithNamespace("/nope/nada/iac")
+                .nameWithNamespace("/ nope / nada / iac").build()).build();
+
+        Exception ex = assertThrows(WebApplicationException.class, () -> {
+            engagementService.updateStatusAndCommits(hook);
+        });
+
+        assertEquals("no engagement found. unable to update from hook.", ex.getMessage());
+    }
+
+    @Test
+    void testAlreadyLaunched() {
+        Engagement engagement = Engagement.builder().launch(Launch.builder().build()).build();
+
+        Exception ex = assertThrows(WebApplicationException.class, () -> {
+            engagementService.launch(engagement);
+        });
+
+        assertEquals("engagement has already been launched.", ex.getMessage());
+    }
+
+    @Test
+    void testUpdateRemoveAllUsers() {
+
+        // persisted engagement
+        EngagementUser user1 = mockEngagementUser("jj@example.com", "John", "Johnson", "admin", "1234");
+        EngagementUser user2 = mockEngagementUser("js@example.com", "Jeff", "Smith", "observer", "6789");
+        Engagement existing = mockMinimumEngagement("c1", "p1", "00000");
+        existing.setEngagementUsers(Sets.newSet(user1, user2));
+
+        // requested update engagement
+        Engagement toUpdate = mockMinimumEngagement("c1", "p1", "00000");
+        toUpdate.setLastUpdate(ZonedDateTime.now(ZoneId.of("Z")).toString());
+
+        // repository mocks
+        Mockito.when(repository.findByUiid("00000")).thenReturn(Optional.of(existing));
+        Mockito.when(repository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(Optional.of(toUpdate));
+
+        Engagement response = engagementService.update(toUpdate);
+
+        assertNotNull(response);
+        assertEquals("c1", response.getCustomerName());
+        assertEquals("p1", response.getProjectName());
+        assertNull(response.getEngagementUsers());
+
+    }
+
+    @Test
+    void testUpdateAllNewUsers() {
+
+        // persisted engagement
+        Engagement existing = mockMinimumEngagement("c1", "p1", "00000");
+
+        // requested update engagement
+        EngagementUser user1 = mockEngagementUser("jj@example.com", "John", "Johnson", "admin", null);
+
+        Engagement toUpdate = mockMinimumEngagement("c1", "p1", "00000");
+        toUpdate.setEngagementUsers(Sets.newSet(user1));
+        toUpdate.setLastUpdate(ZonedDateTime.now(ZoneId.of("Z")).toString());
+
+        // repository mocks
+        Mockito.when(repository.findByUiid("00000")).thenReturn(Optional.of(existing));
+        Mockito.when(repository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(Optional.of(toUpdate));
+
+        Engagement response = engagementService.update(toUpdate);
+
+        assertNotNull(response);
+        assertEquals("c1", response.getCustomerName());
+        assertEquals("p1", response.getProjectName());
+        assertNotNull(response.getEngagementUsers());
+        assertEquals(1, response.getEngagementUsers().size());
+
+        EngagementUser actualUser = response.getEngagementUsers().iterator().next();
+        assertNotNull(actualUser);
+        assertEquals("jj@example.com", actualUser.getEmail());
+        assertEquals("John", actualUser.getFirstName());
+        assertEquals("Johnson", actualUser.getLastName());
+        assertEquals("admin", actualUser.getRole());
+        assertNotNull(actualUser.getUuid());
+
+    }
+
+    @Test
+    void testUpdateNewAndExistingUsers() {
+
+        // persisted engagement
+        EngagementUser user1 = mockEngagementUser("jj@example.com", "John", "Johnson", "admin", "1234");
+        Engagement existing = mockMinimumEngagement("c1", "p1", "00000");
+        existing.setEngagementUsers(Sets.newSet(user1));
+
+        // requested update engagement
+        EngagementUser user2 = mockEngagementUser("js@example.com", "Jeff", "Smith", "observer", null);
+        Engagement toUpdate = mockMinimumEngagement("c1", "p1", "00000");
+        toUpdate.setEngagementUsers(Sets.newSet(user1, user2));
+        toUpdate.setLastUpdate(ZonedDateTime.now(ZoneId.of("Z")).toString());
+
+        // repository mocks
+        Mockito.when(repository.findByUiid("00000")).thenReturn(Optional.of(existing));
+        Mockito.when(repository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(Optional.of(toUpdate));
+
+        Engagement response = engagementService.update(toUpdate);
+
+        assertNotNull(response);
+        assertEquals("c1", response.getCustomerName());
+        assertEquals("p1", response.getProjectName());
+        assertNotNull(response.getEngagementUsers());
+        assertEquals(2, response.getEngagementUsers().size());
+
+        for (EngagementUser user : response.getEngagementUsers()) {
+
+            if (user.getEmail().equals("jj@example.com")) {
+                assertEquals("jj@example.com", user.getEmail());
+                assertEquals("John", user.getFirstName());
+                assertEquals("Johnson", user.getLastName());
+                assertEquals("admin", user.getRole());
+                assertEquals("1234", user.getUuid());
+            } else {
+                assertEquals("js@example.com", user.getEmail());
+                assertEquals("Jeff", user.getFirstName());
+                assertEquals("Smith", user.getLastName());
+                assertEquals("observer", user.getRole());
+                assertNotNull(user.getUuid());
+            }
+
+        }
+
+    }
+
+    @Test
+    void testSetNullUuidsEngagementUuid() {
+
+        Engagement e1 = mockMinimumEngagement("c1", "p1", null);
+        Engagement e2 = mockMinimumEngagement("c1", "p1", "5678");
+
+        Mockito.when(repository.streamAll()).thenReturn(Stream.of(e1, e2));
+
+        assertEquals(1, engagementService.setNullUuids());
+
+    }
+
+    @Test
+    void testSetNullUuidsEngagementUsersUuid() {
+
+        EngagementUser user1 = mockEngagementUser("jj@example.com", "John", "Johnson", "admin", "1234");
+        Engagement e1 = mockMinimumEngagement("c1", "p1", "1234");
+        e1.setEngagementUsers(Sets.newSet(user1));
+
+        EngagementUser user2 = mockEngagementUser("js@example.com", "Jeff", "Smith", "observer", null);
+        Engagement e2 = mockMinimumEngagement("c1", "p1", "5678");
+        e2.setEngagementUsers(Sets.newSet(user2));
+
+        Mockito.when(repository.streamAll()).thenReturn(Stream.of(e1, e2));
+
+        assertEquals(1, engagementService.setNullUuids());
+
+    }
+
+    @Test
+    void testSetNullUuidsOnEngagementAndEngagementUsersUuid() {
+
+        EngagementUser user1 = mockEngagementUser("jj@example.com", "John", "Johnson", "admin", "1234");
+        Engagement e1 = mockMinimumEngagement("c1", "p1", null);
+        e1.setEngagementUsers(Sets.newSet(user1));
+
+        EngagementUser user2 = mockEngagementUser("js@example.com", "Jeff", "Smith", "observer", null);
+        Engagement e2 = mockMinimumEngagement("c1", "p1", "5678");
+        e2.setEngagementUsers(Sets.newSet(user2));
+
+        Mockito.when(repository.streamAll()).thenReturn(Stream.of(e1, e2));
+
+        assertEquals(2, engagementService.setNullUuids());
+
+    }
+
+    Engagement mockMinimumEngagement(String customerName, String projectName, String uuid) {
+        return Engagement.builder().customerName(customerName).projectName(projectName).uuid(uuid).build();
+    }
+
+    EngagementUser mockEngagementUser(String email, String firstName, String lastName, String role, String uuid) {
+        return EngagementUser.builder().email(email).firstName(firstName).lastName(lastName).role(role).uuid(uuid)
+                .build();
+    }
+
 }


### PR DESCRIPTION
- `EngagementUser` now exposes a `reset` attribute that will trigger a user reset on the orchestration side
- `EngagementUser` now exposes a `uuid` attribute to uniquely identifier a user
- automatically sets UUIDs for `EngagementUsers` if null in mongo or on creation of new user
