### PR TITLE
Add Filtering to GET APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .classpath
 .settings/
 bin/
+.env
+
+.factorypath
 
 # IntelliJ
 .idea

--- a/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
@@ -58,6 +58,8 @@ public class Engagement extends PanacheMongoEntityBase {
     private String customerContactName;
     @JsonbProperty("customer_contact_email")
     private String customerContactEmail;
+    @JsonbProperty("hosting_environments")
+    private List<HostingEnvironment> hostingEnvironments;
     @JsonbProperty("ocp_cloud_provider_name")
     private String ocpCloudProviderName;
     @JsonbProperty("ocp_cloud_provider_region")
@@ -77,7 +79,7 @@ public class Engagement extends PanacheMongoEntityBase {
     private Launch launch;
     @JsonbProperty("engagement_users")
     private List<EngagementUser> engagementUsers;
-    
+
     private Status status;
     private List<Commit> commits;
     @JsonbProperty("creation_details")

--- a/src/main/java/com/redhat/labs/lodestar/model/EngagementUser.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/EngagementUser.java
@@ -34,7 +34,7 @@ public class EngagementUser {
         if (getClass() != obj.getClass())
             return false;
         EngagementUser other = (EngagementUser) obj;
-        if (email == null && other.email != null) {
+        if ((email == null && other.email != null) || (email != null && other.email == null)) {
             return false;
         }
         return email.equals(other.email);

--- a/src/main/java/com/redhat/labs/lodestar/model/HostingEnvironment.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/HostingEnvironment.java
@@ -1,0 +1,43 @@
+package com.redhat.labs.lodestar.model;
+
+import javax.json.bind.annotation.JsonbProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HostingEnvironment {
+
+    @JsonbProperty("id")
+    private String id;
+
+    @JsonbProperty("environment_name")
+    private String environmentName;
+
+    @JsonbProperty("additional_details")
+    private String additionalDetails;
+
+    @JsonbProperty("ocp_cloud_provider_name")
+    private String ocpCloudProviderName;
+
+    @JsonbProperty("ocp_cloud_provider_region")
+    private String ocpCloudProviderRegion;
+
+    @JsonbProperty("ocp_persistent_storage_size")
+    private String ocpPersistentStorageSize;
+
+    @JsonbProperty("ocp_sub_domain")
+    private String ocpSubDomain;
+
+    @JsonbProperty("ocp_version")
+    private String ocpVersion;
+
+    @JsonbProperty("ocp_cluster_size")
+    private String ocpClusterSize;
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -44,7 +44,7 @@ import io.quarkus.mongodb.panache.PanacheMongoRepository;
 @ApplicationScoped
 public class EngagementRepository implements PanacheMongoRepository<Engagement> {
 
-    public static final List<String> IMMUTABLE_FIELDS = new ArrayList<>(
+    private static final List<String> IMMUTABLE_FIELDS = new ArrayList<>(
             Arrays.asList("uuid", "mongoId", "projectId", "creationDetails", "status", "commits", "launch"));
 
     private ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -54,6 +54,19 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
     private ObjectMapper objectMapper = new ObjectMapper();
 
     /**
+     * Returns Optional containing an {@link Engagement} that matches the provided
+     * subdomain.
+     * 
+     * @param subdomain
+     * @return
+     */
+    public Optional<Engagement> findBySubdomain(String subdomain) {
+        String regex = new StringBuilder("^").append(subdomain).append("$").toString();
+        Bson filter = regex("ocpSubDomain", regex, "im");
+        return Optional.ofNullable(mongoCollection().find(filter).first());
+    }
+
+    /**
      * Returns a {@link List} of {@link Engagement}s where the action attribute is
      * not null.
      * 

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -60,8 +60,7 @@ public class EngagementResource {
 
     @POST
     @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "409", description = "Engagement resource already exists"),
             @APIResponse(responseCode = "201", description = "Engagement stored in database") })
     @Operation(summary = "Creates the engagement resource in the database.")
@@ -85,8 +84,7 @@ public class EngagementResource {
     @Deprecated
     @SecurityRequirement(name = "jwt", scopes = {})
     @Path("/customers/{customerName}/projects/{projectName}")
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "404", description = "Engagement resource not found to update"),
             @APIResponse(responseCode = "200", description = "Engagement updated in the database") })
     @Operation(deprecated = true, summary = "Updates the engagement resource in the database.")
@@ -105,19 +103,15 @@ public class EngagementResource {
     @Deprecated
     @SecurityRequirement(name = "jwt", scopes = {})
     @Path("/customers/{customerName}/projects/{projectName}")
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "404", description = "Engagement resource with customer and project names does not exist"),
             @APIResponse(responseCode = "200", description = "Engagement resource found and returned") })
     @Operation(deprecated = true, summary = "Returns the engagement resource for the given customer and project names.")
-    public Response get(@PathParam("customerName") String customerName,
-            @PathParam("projectName") String projectName) {
+    public Response get(@PathParam("customerName") String customerName, @PathParam("projectName") String projectName) {
 
         Engagement engagement = engagementService.getByCustomerAndProjectName(customerName, projectName);
-        return Response.ok(engagement)
-                .header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
-                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER)
-                .build();
+        return Response.ok(engagement).header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
+                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER).build();
 
     }
 
@@ -125,26 +119,21 @@ public class EngagementResource {
     @Deprecated
     @SecurityRequirement(name = "jwt", scopes = {})
     @Path("/customers/{customerName}/projects/{projectName}")
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "404", description = "Engagement resource with customer and project names does not exist"),
             @APIResponse(responseCode = "200", description = "Engagement resource found and metadata returned in headers") })
     @Operation(deprecated = true, summary = "Returns metadata regarding the engagement resource for the given customer and project names.")
-    public Response head(@PathParam("customerName") String customerName,
-            @PathParam("projectName") String projectName) {
+    public Response head(@PathParam("customerName") String customerName, @PathParam("projectName") String projectName) {
 
         Engagement engagement = engagementService.getByCustomerAndProjectName(customerName, projectName);
-        return Response.ok()
-                .header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
-                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER)
-                .build();
+        return Response.ok().header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
+                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER).build();
 
     }
 
     @GET
     @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "200", description = "A list or empty list of engagement resources returned") })
     @Operation(summary = "Returns all engagement resources from the database.  Can be empty list if none found.")
     public List<Engagement> getAll(@QueryParam("categories") String categories) {
@@ -154,8 +143,7 @@ public class EngagementResource {
     @GET
     @Path("/customers/suggest")
     @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "200", description = "Customer data has been returned.") })
     @Operation(summary = "Returns customers list")
     public Response findCustomers(@NotBlank @QueryParam("suggest") String match) {
@@ -168,8 +156,7 @@ public class EngagementResource {
     @GET
     @Path("/categories")
     @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "200", description = "Customer data has been returned.") })
     @Operation(summary = "Returns customers list")
     public List<Category> getAllCategories(@QueryParam("suggest") String match) {
@@ -179,8 +166,7 @@ public class EngagementResource {
     @GET
     @Path("/artifact/types")
     @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "200", description = "Artifact types have been returned.") })
     @Operation(summary = "Returns artifact type list")
     public List<String> getArtifactTypes(@QueryParam("suggest") String match) {
@@ -190,8 +176,7 @@ public class EngagementResource {
     @PUT
     @Path("/launch")
     @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "200", description = "Launch data added to engagement resource and persisted to git") })
     @Operation(summary = "Adds launch data to the engagement resource and immediately persists it to git.")
     public Engagement launch(@Valid Engagement engagement) {
@@ -208,9 +193,8 @@ public class EngagementResource {
     @PUT
     @Path("/refresh")
     @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = {
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
-            @APIResponse(responseCode = "202", description = "The request was accepted and will be processed.")})
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "202", description = "The request was accepted and will be processed.") })
     @Operation(summary = "Refreshes database with data in git, purging first if the query paramater set to true.")
     public Response refresh(@QueryParam("purgeFirst") Boolean purgeFirst) {
 
@@ -223,44 +207,37 @@ public class EngagementResource {
     @GET
     @SecurityRequirement(name = "jwt", scopes = {})
     @Path("/{id}")
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "404", description = "Engagement resource with id does not exist"),
             @APIResponse(responseCode = "200", description = "Engagement resource found and returned") })
     @Operation(summary = "Returns the engagement resource for the given id.")
     public Response get(@PathParam("id") String uuid) {
 
         Engagement engagement = engagementService.getByUuid(uuid);
-        return Response.ok(engagement)
-                .header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
-                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER)
-                .build();
+        return Response.ok(engagement).header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
+                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER).build();
 
     }
 
     @HEAD
     @SecurityRequirement(name = "jwt", scopes = {})
     @Path("/{id}")
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "404", description = "Engagement resource with customer and project names does not exist"),
             @APIResponse(responseCode = "200", description = "Engagement resource found and metadata returned in headers") })
     @Operation(summary = "Returns metadata regarding the engagement resource for the given customer and project names.")
     public Response head(@PathParam("id") String uuid) {
 
         Engagement engagement = engagementService.getByUuid(uuid);
-        return Response.ok()
-                .header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
-                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER)
-                .build();
+        return Response.ok().header(LAST_UPDATE_HEADER, engagement.getLastUpdate())
+                .header(ACCESS_CONTROL_EXPOSE_HEADER, LAST_UPDATE_HEADER).build();
 
     }
 
     @PUT
     @SecurityRequirement(name = "jwt", scopes = {})
     @Path("/{id}")
-    @APIResponses(value = { 
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
             @APIResponse(responseCode = "404", description = "Engagement resource not found to update"),
             @APIResponse(responseCode = "200", description = "Engagement updated in the database") })
     @Operation(summary = "Updates the engagement resource in the database.")
@@ -279,14 +256,14 @@ public class EngagementResource {
         // Use `name` claim first
         Optional<String> optional = claimIsValid(NAME_CLAIM);
 
-        if(optional.isPresent()) {
+        if (optional.isPresent()) {
             return optional.get();
         }
 
         // use `preferred_username` claim if `name` not valid
         optional = claimIsValid(PREFERRED_USERNAME_CLAIM);
 
-        if(optional.isPresent()) {
+        if (optional.isPresent()) {
             return optional.get();
         }
 
@@ -297,9 +274,9 @@ public class EngagementResource {
 
     private String getUserEmailFromToken() {
 
-        Optional<String >optional = claimIsValid(USER_EMAIL_CLAIM);
+        Optional<String> optional = claimIsValid(USER_EMAIL_CLAIM);
 
-        if(optional.isPresent()) {
+        if (optional.isPresent()) {
             return optional.get();
         }
 

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -17,6 +17,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/src/test/java/com/redhat/labs/lodestar/resources/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resources/EngagementResourceTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 
-import org.jose4j.json.internal.json_simple.JSONArray;
 import org.jose4j.json.internal.json_simple.JSONObject;
 import org.jose4j.json.internal.json_simple.parser.JSONParser;
 import org.jose4j.json.internal.json_simple.parser.ParseException;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
 import com.redhat.labs.lodestar.model.Engagement;
-import com.redhat.labs.lodestar.model.EngagementUser;
 import com.redhat.labs.lodestar.rest.client.MockLodeStarGitLabAPIService.SCENARIO;
 import com.redhat.labs.lodestar.utils.EmbeddedMongoTest;
 import com.redhat.labs.lodestar.utils.TokenUtils;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,48 +1,37 @@
 # jwt verification configuration
 mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem
 mp.jwt.verify.issuer=https://quarkus.io/using-jwt-rbac
-
 # enable jwt support
 quarkus.smallrye-jwt.enabled=true
-
 # allow all for the web socket endpoint - will be authenticated using filter
 quarkus.http.auth.permission.permit1.paths=/engagements/events/*
 quarkus.http.auth.permission.permit1.policy=permit
 quarkus.http.auth.permission.permit1.methods=GET
-
 # define auth roles
 quarkus.http.auth.policy.role-reader.roles-allowed=reader,writer
 quarkus.http.auth.policy.role-writer.roles-allowed=writer
-
 # set the /config endpoint(s) to reader or admin role
 quarkus.http.auth.permission.read.paths=/config
 quarkus.http.auth.permission.read.policy=role-reader
-
 # set the /engagements/* endpoint(s) to writer for PUT and POST methods
 quarkus.http.auth.permission.writer.paths=/engagements/*
 quarkus.http.auth.permission.writer.policy=role-writer
 quarkus.http.auth.permission.writer.methods=PUT,POST
-
 # set the /engagements/* endpoint(s) to reader for other methods
 quarkus.http.auth.permission.reader.paths=/engagements/*
 quarkus.http.auth.permission.reader.policy=role-reader
-
 # mongo
-quarkus.mongodb.connection-string = mongodb://localhost:12345
-quarkus.mongodb.database = engagement
+quarkus.mongodb.connection-string=mongodb://localhost:12345
+quarkus.mongodb.database=engagement
 quarkus.mongodb.write-concern.journal=false
-
 # effectively disable
 auto.save.cron.expr=0 0 0 1 1 ? 2098
 auto.repopulate.cron.expr=0 0 0 1 1 ? 2098
-
 git.commit=abcdef
 git.tag=master
 version.yml=src/test/resources/version-manifest.yaml
 status.file=status.json
 webhook.token=ttttt
 cleanup.token=CLEANUP
-
 quarkus.mongodb.database=engagement
 quarkus.mongodb.connection-string=mongodb://localhost:12345/${quarkus.mongodb.database}?uuidRepresentation=javaLegacy
-


### PR DESCRIPTION
- added filtering options `include` and `exclude` to the following:
  - `GET` `/engagements`
  - `GET` `/engagements/customers/{customerName}/projects/{projectName}`
  - `GET` `/engagements/{uuid}`

- Returns 400 if both `include` and `exclude` specified
- Clients can build the response they want by supplying a comma separated list of fields using the `include` 
- Clients can remove fields from the response they want by supplying a comma separated list of fields using the `exclude`
- If no lists supplied for `include` or `exclude` all fields will be returned 