### PR TITLE
Unique Subdomain

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
@@ -61,18 +61,6 @@ public class Engagement extends PanacheMongoEntityBase {
     private String customerContactEmail;
     @JsonbProperty("hosting_environments")
     private List<HostingEnvironment> hostingEnvironments;
-    @JsonbProperty("ocp_cloud_provider_name")
-    private String ocpCloudProviderName;
-    @JsonbProperty("ocp_cloud_provider_region")
-    private String ocpCloudProviderRegion;
-    @JsonbProperty("ocp_version")
-    private String ocpVersion;
-    @JsonbProperty("ocp_sub_domain")
-    private String ocpSubDomain;
-    @JsonbProperty("ocp_persistent_storage_size")
-    private String ocpPersistentStorageSize;
-    @JsonbProperty("ocp_cluster_size")
-    private String ocpClusterSize;
     @JsonbProperty("public_reference")
     private boolean publicReference;
     @JsonProperty("additional_details")

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -55,9 +55,24 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
     }
 
     public Optional<Engagement> findBySubdomain(String subdomain) {
+        return findBySubdomain(subdomain, Optional.empty(), Optional.empty());
+    }
+
+    public Optional<Engagement> findBySubdomain(String subdomain, Optional<String> engagementUuid, Optional<String> environmentName) {
+
         String regex = new StringBuilder("^").append(subdomain).append("$").toString();
-        Bson filter = regex("ocpSubDomain", regex, "im");
+        Bson filter = regex("hostingEnvironments.ocpSubDomain", regex, "im");
+
+        if(engagementUuid.isPresent()) {
+            filter = and(eq("uuid", engagementUuid.get()));
+        }
+
+        if(environmentName.isPresent()) {
+            filter = and(eq("hostingEnvironments.environmentName", environmentName.get()));
+        }
+
         return Optional.ofNullable(mongoCollection().find(filter).first());
+
     }
 
     public List<Engagement> findByModified() {

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -55,20 +55,16 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
     }
 
     public Optional<Engagement> findBySubdomain(String subdomain) {
-        return findBySubdomain(subdomain, Optional.empty(), Optional.empty());
+        return findBySubdomain(subdomain, Optional.empty());
     }
 
-    public Optional<Engagement> findBySubdomain(String subdomain, Optional<String> engagementUuid, Optional<String> environmentName) {
+    public Optional<Engagement> findBySubdomain(String subdomain, Optional<String> engagementUuid) {
 
         String regex = new StringBuilder("^").append(subdomain).append("$").toString();
         Bson filter = regex("hostingEnvironments.ocpSubDomain", regex, "im");
 
         if(engagementUuid.isPresent()) {
-            filter = and(eq("uuid", engagementUuid.get()));
-        }
-
-        if(environmentName.isPresent()) {
-            filter = and(eq("hostingEnvironments.environmentName", environmentName.get()));
+            filter = and(filter, eq("uuid", engagementUuid.get()));
         }
 
         return Optional.ofNullable(mongoCollection().find(filter).first());

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -17,7 +17,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -241,7 +241,7 @@ public class EngagementService {
             List<String> subdomainsInUse = toUpdate.getHostingEnvironments().stream()
                     .filter(he -> null != he.getOcpSubDomain())
                     .filter(he -> repository.findBySubdomain(he.getOcpSubDomain(),
-                            Optional.ofNullable(toUpdate.getUuid()), Optional.ofNullable(he.getEnvironmentName()))
+                            Optional.ofNullable(toUpdate.getUuid()))
                             .isEmpty())
                     .filter(he -> repository.findBySubdomain(he.getOcpSubDomain()).isPresent())
                     .map(he -> he.getOcpSubDomain())

--- a/src/test/java/com/redhat/labs/lodestar/resources/GitSyncResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resources/GitSyncResourceTest.java
@@ -47,7 +47,6 @@ public class GitSyncResourceTest {
         String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
 
         Engagement engagement = mockEngagement();
-        engagement.setOcpSubDomain(null);
         engagement.setDescription(SCENARIO.SUCCESS.getValue());
 
         String body = quarkusJsonb.toJson(engagement);
@@ -86,7 +85,6 @@ public class GitSyncResourceTest {
 
         // update description
         created.setDescription("updated");
-        created.setOcpSubDomain(null);
         body = quarkusJsonb.toJson(created);
 
         // PUT engagement - update
@@ -209,7 +207,6 @@ public class GitSyncResourceTest {
         engagement.setCustomerName("AnotherTestCustomer");
         engagement.setProjectName("AnotherTestProject");
         engagement.setDescription(SCENARIO.SUCCESS.getValue());
-        engagement.setOcpSubDomain(null);
         body = quarkusJsonb.toJson(engagement);
 
         // POST engagement - create
@@ -244,9 +241,7 @@ public class GitSyncResourceTest {
                 .description("Test Description").location("Raleigh, NC").startDate("20170501").endDate("20170708")
                 .archiveDate("20170930").engagementLeadName("Mister Lead").engagementLeadEmail("mister@lead.com")
                 .technicalLeadName("Mister Techlead").technicalLeadEmail("mister@techlead.com")
-                .customerContactName("Customer Contact").customerContactEmail("customer@contact.com")
-                .ocpCloudProviderName("GCP").ocpCloudProviderRegion("West").ocpVersion("v4.2").ocpSubDomain("jello")
-                .ocpPersistentStorageSize("50GB").ocpClusterSize("medium").build();
+                .customerContactName("Customer Contact").customerContactEmail("customer@contact.com").build();
 
         return engagement;
 

--- a/src/test/java/com/redhat/labs/lodestar/resources/StatusResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resources/StatusResourceTest.java
@@ -34,7 +34,7 @@ public class StatusResourceTest {
     
     @BeforeEach
     public void seed() {
-        Engagement engagement = Engagement.builder().customerName("jello").projectName("exists").ocpSubDomain("").build();
+        Engagement engagement = Engagement.builder().customerName("jello").projectName("exists").build();
         engagementService.create(engagement);
     }
     


### PR DESCRIPTION
- on create, validates no other engagement exists with any hosting environment subdomain, if provided on `POST /engagements`
- on update, validates no other engagement exists with any hosting environment subdomain, if provided on `PUT /engagements/{uuid}`
  - skips check if engagement uuid matches (i.e. skip subdomain check if the subdomain found is on the engagement being updated.