### PR TITLE
Remove Project ID Check on Update

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -180,7 +180,6 @@ public class EngagementService {
         Engagement existing = getByIdOrName(engagement).orElseThrow(
                 () -> new WebApplicationException("no engagement found, use POST to create", HttpStatus.SC_NOT_FOUND));
 
-        validateProjectIdExists(existing);
         String currentLastUpdated = engagement.getLastUpdate();
         validateHostingEnvironments(engagement.getHostingEnvironments());
         validateSubdomainOnUpdate(engagement);
@@ -207,20 +206,6 @@ public class EngagementService {
         eventBus.sendAndForget(EventType.UPDATE_ENGAGEMENT_EVENT_ADDRESS, copy);
 
         return updated;
-
-    }
-
-    /**
-     * Throws a {@link WebApplicationException} if the project ID is missing from
-     * the given {@link Engagement}.
-     * 
-     * @param engagement
-     */
-    void validateProjectIdExists(Engagement engagement) {
-
-        if (null == engagement.getProjectId()) {
-            throw new WebApplicationException("cannot updated engagement: missing project id.", 500);
-        }
 
     }
 


### PR DESCRIPTION
removing this check because the `git-api` will look up the project based on customer/engagement names if the project id is not supplied by the `backend`. 