### PR TITLE
BugFixes - Name Length and Retry

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -147,6 +147,10 @@ public class EngagementService {
         engagement.setCustomerName(engagement.getCustomerName().trim());
         engagement.setProjectName(engagement.getProjectName().trim());
 
+        // names cannot be greater than 255 in length because of gitlab
+        validateNameLength(engagement.getCustomerName());
+        validateNameLength(engagement.getProjectName());
+
     }
 
     /**
@@ -219,6 +223,10 @@ public class EngagementService {
      */
     void validateCustomerAndProjectNames(Engagement toUpdate, Engagement existing) {
 
+        // names cannot be greater than 255 in length because of gitlab
+        validateNameLength(toUpdate.getCustomerName());
+        validateNameLength(toUpdate.getProjectName());
+
         // return if names have not changed
         if (toUpdate.getCustomerName().equals(existing.getCustomerName())
                 && toUpdate.getProjectName().equals(existing.getProjectName())) {
@@ -236,6 +244,21 @@ public class EngagementService {
         throw new WebApplicationException("failed to change name(s).  engagement with customer name '"
                 + toUpdate.getCustomerName() + "' and project '" + toUpdate.getProjectName() + "' already exists.",
                 409);
+
+    }
+
+    /**
+     * Throws a {@link WebApplicationException} if the provided name is greater than
+     * 255 characters.
+     * 
+     * @param name
+     */
+    void validateNameLength(String name) {
+
+        if (name.length() > 255) {
+            throw new WebApplicationException("names cannot be greater than 255 characters.",
+                    HttpStatus.SC_BAD_REQUEST);
+        }
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
@@ -152,7 +152,6 @@ class EventServiceTest extends IntegrationTestHelper {
 
         Mockito.verify(gitApiClient, Mockito.timeout(1000).times(1)).createOrUpdateEngagement(e, "someone",
                 "someone@example.com");
-//        Mockito.verify(engagementService, Mockito.timeout(1000).times(0)).setProjectId("1234", 5678);
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
@@ -137,6 +137,26 @@ class EventServiceTest extends IntegrationTestHelper {
     }
 
     @Test
+    void testConsumeUpdateEngagementEventRetryEngagementRemoved() {
+
+        Response created = Response.status(201).header("Location", "some/path/to/id/5678").build();
+        Engagement e = Engagement.builder().uuid("1234").customerName("c1").projectName("p1")
+                .lastUpdateByName("someone").lastUpdateByEmail("someone@example.com")
+                .lastUpdate(ZonedDateTime.now(ZoneId.of("Z")).toString()).build();
+
+        Mockito.when(gitApiClient.createOrUpdateEngagement(Mockito.any(), Mockito.anyString(), Mockito.anyString()))
+                .thenThrow(new WebApplicationException(500)).thenReturn(created);
+        Mockito.when(engagementService.getByUuid(Mockito.anyString(), Mockito.any())).thenThrow(new WebApplicationException(404));
+
+        eventBus.sendAndForget(EventType.UPDATE_ENGAGEMENT_EVENT_ADDRESS, e);
+
+        Mockito.verify(gitApiClient, Mockito.timeout(1000).times(1)).createOrUpdateEngagement(e, "someone",
+                "someone@example.com");
+//        Mockito.verify(engagementService, Mockito.timeout(1000).times(0)).setProjectId("1234", 5678);
+
+    }
+
+    @Test
     void testConsumeUpdateEngagementEventMaxRetriesReached() {
 
         Mockito.when(gitApiClient.createOrUpdateEngagement(Mockito.any(), Mockito.anyString(), Mockito.anyString()))


### PR DESCRIPTION
- throws bad request if customer or project name greater than 255 on create or update
- exits retry if engagement has been deleted before the next retry