### PR TITLE
Database Population Performance Improvements Using Paging

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/exception/mapper/LodeStarGitLabAPIServiceResponseMapper.java
+++ b/src/main/java/com/redhat/labs/lodestar/exception/mapper/LodeStarGitLabAPIServiceResponseMapper.java
@@ -21,10 +21,18 @@ public class LodeStarGitLabAPIServiceResponseMapper implements ResponseException
     }
 
     private String getBody(Response response) {
-        ByteArrayInputStream is = (ByteArrayInputStream) response.getEntity();
-        byte[] bytes = new byte[is.available()];
-        is.read(bytes, 0, is.available());
-        return new String(bytes);
+
+        if (response.hasEntity()) {
+
+            ByteArrayInputStream is = (ByteArrayInputStream) response.getEntity();
+            byte[] bytes = new byte[is.available()];
+            is.read(bytes, 0, is.available());
+            return new String(bytes);
+
+        }
+
+        return null;
+
     }
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/event/EventType.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/event/EventType.java
@@ -20,7 +20,6 @@ public class EventType {
     public static final String GET_PAGE_OF_ENGAGEMENTS_EVENT_ADDRESS = "get.page.of.engagements.event";
     public static final String PERSIST_ENGAGEMENT_LIST_EVENT_ADDRESS = "persist.engagement.list.event";
     public static final String PERSIST_ENGAGEMENT_EVENT_ADDRESS = "persist.engagement.event";
-    public static final String SET_STATUS_COMMITS_EVENT_ADDRESS = "set.status.commits.event.address";
     public static final String UPDATE_COMMITS_EVENT_ADDRESS = "update.commits.event";
     public static final String UPDATE_STATUS_EVENT_ADDRESS = "update.status.event";
 

--- a/src/main/java/com/redhat/labs/lodestar/model/event/EventType.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/event/EventType.java
@@ -5,14 +5,23 @@ public class EventType {
     private EventType() {
         throw new IllegalStateException("Utility class");
     }
-    
+
     public static final String CREATE_ENGAGEMENT_EVENT_ADDRESS = "create.engagement.event";
     public static final String UPDATE_ENGAGEMENT_EVENT_ADDRESS = "update.engagement.event";
     public static final String DELETE_ENGAGEMENT_EVENT_ADDRESS = "delete.engagement.event";
-    public static final String REFRESH_DATABASE_EVENT_ADDRESS = "refresh.database.event";
+
     public static final String SET_UUID_EVENT_ADDRESS = "set.uuid.event";
     public static final String RETRY_CREATE_EVENT_ADDRESS = "retry.create.event";
     public static final String RETRY_UPDATE_EVENT_ADDRESS = "retry.update.event";
     public static final String RETRY_DELETE_EVENT_ADDRESS = "retry.delete.event";
 
-} 
+    public static final String LOAD_DATABASE_EVENT_ADDRESS = "load.database.event";
+    public static final String DELETE_AND_RELOAD_DATABASE_EVENT_ADDRESS = "delete.and.reload.database.event";
+    public static final String GET_PAGE_OF_ENGAGEMENTS_EVENT_ADDRESS = "get.page.of.engagements.event";
+    public static final String PERSIST_ENGAGEMENT_LIST_EVENT_ADDRESS = "persist.engagement.list.event";
+    public static final String PERSIST_ENGAGEMENT_EVENT_ADDRESS = "persist.engagement.event";
+    public static final String SET_STATUS_COMMITS_EVENT_ADDRESS = "set.status.commits.event.address";
+    public static final String UPDATE_COMMITS_EVENT_ADDRESS = "update.commits.event";
+    public static final String UPDATE_STATUS_EVENT_ADDRESS = "update.status.event";
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -41,8 +41,10 @@ import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.Sorts;
 import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
+import com.redhat.labs.lodestar.model.Commit;
 import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.FilterOptions;
+import com.redhat.labs.lodestar.model.Status;
 
 import io.quarkus.mongodb.panache.PanacheMongoRepository;
 
@@ -172,8 +174,7 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
                 group("$artifacts.lower_type"), project(new Document().append("type", "$_id")),
                 sort(Sorts.ascending("type"))), Artifact.class);
 
-        return StreamSupport.stream(iterable.spliterator(), false).map(Artifact::getType)
-                .collect(Collectors.toList());
+        return StreamSupport.stream(iterable.spliterator(), false).map(Artifact::getType).collect(Collectors.toList());
 
     }
 
@@ -189,6 +190,42 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
 
         Bson filter = eq("uuid", uuid);
         Bson update = set("projectId", projectId);
+
+        FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
+
+        return Optional.ofNullable(this.mongoCollection().findOneAndUpdate(filter, update, optionAfter));
+
+    }
+
+    /**
+     * Sets the {@link Status} for the given UUID.
+     * 
+     * @param uuid
+     * @param status
+     * @return
+     */
+    public Optional<Engagement> setStatus(String uuid, Status status) {
+
+        Bson filter = eq("uuid", uuid);
+        Bson update = set("status", status);
+
+        FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
+
+        return Optional.ofNullable(this.mongoCollection().findOneAndUpdate(filter, update, optionAfter));
+
+    }
+
+    /**
+     * Sets the {@link Commit}s for the given UUID.
+     * 
+     * @param uuid
+     * @param commits
+     * @return
+     */
+    public Optional<Engagement> setCommits(String uuid, List<Commit> commits) {
+
+        Bson filter = eq("uuid", uuid);
+        Bson update = set("commits", commits);
 
         FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
 

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -25,11 +25,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import com.redhat.labs.lodestar.model.Category;
-import com.redhat.labs.lodestar.model.Engagement;
-import com.redhat.labs.lodestar.model.FilterOptions;
-import com.redhat.labs.lodestar.service.EngagementService;
-
 import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -38,6 +33,13 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import com.redhat.labs.lodestar.model.Category;
+import com.redhat.labs.lodestar.model.Engagement;
+import com.redhat.labs.lodestar.model.FilterOptions;
+import com.redhat.labs.lodestar.rest.client.LodeStarGitLabAPIService;
+import com.redhat.labs.lodestar.service.EngagementService;
 
 @RequestScoped
 @Path("/engagements")
@@ -55,6 +57,10 @@ public class EngagementResource {
 
     public static final String ACCESS_CONTROL_EXPOSE_HEADER = "Access-Control-Expose-Headers";
     public static final String LAST_UPDATE_HEADER = "last-update";
+
+    @Inject
+    @RestClient
+    LodeStarGitLabAPIService gitApi;
 
     @Inject
     JsonWebToken jwt;
@@ -204,7 +210,7 @@ public class EngagementResource {
     public Response refresh(@QueryParam("purgeFirst") Boolean purgeFirst) {
 
         // start the sync process
-        engagementService.syncGitToDatabase((null == purgeFirst) ? false : purgeFirst);
+        engagementService.syncGitToDatabase(Boolean.TRUE.equals(purgeFirst));
         return Response.accepted().build();
 
     }

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -33,12 +33,10 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import com.redhat.labs.lodestar.model.Category;
 import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.FilterOptions;
-import com.redhat.labs.lodestar.rest.client.LodeStarGitLabAPIService;
 import com.redhat.labs.lodestar.service.EngagementService;
 
 @RequestScoped
@@ -57,10 +55,6 @@ public class EngagementResource {
 
     public static final String ACCESS_CONTROL_EXPOSE_HEADER = "Access-Control-Expose-Headers";
     public static final String LAST_UPDATE_HEADER = "last-update";
-
-    @Inject
-    @RestClient
-    LodeStarGitLabAPIService gitApi;
 
     @Inject
     JsonWebToken jwt;

--- a/src/main/java/com/redhat/labs/lodestar/rest/client/LodeStarGitLabAPIService.java
+++ b/src/main/java/com/redhat/labs/lodestar/rest/client/LodeStarGitLabAPIService.java
@@ -30,8 +30,10 @@ public interface LodeStarGitLabAPIService {
     @GET
     @Path("/api/v1/engagements")
     @Produces("application/json")
-    List<Engagement> getEngagments();
-    
+    Response getEngagments(@QueryParam("pagination") Boolean pagination, @QueryParam("page") Integer page,
+            @QueryParam("per_page") Integer perPage, @QueryParam("includeStatus") Boolean includeStatus,
+            @QueryParam("includeCommits") Boolean includeCommits);
+
     @GET
     @Path("/api/v1/engagements/namespace/{namespace}")
     @Produces("application/json")
@@ -42,12 +44,12 @@ public interface LodeStarGitLabAPIService {
     @Produces("application/json")
     Response createOrUpdateEngagement(Engagement engagement, @QueryParam("username") String username,
             @QueryParam("userEmail") String userEmail);
-    
+
     @GET
     @Path("/api/v1/engagements/customer/{customer}/{engagement}/status")
     @Produces("application/json")
     Status getStatus(@PathParam("customer") String customer, @PathParam("engagement") String engagement);
-    
+
     @GET
     @Path("/api/v1/engagements/customer/{customer}/{engagement}/commits")
     @Produces("application/json")
@@ -57,7 +59,7 @@ public interface LodeStarGitLabAPIService {
     @Path("/api/v1/engagements/customer/{customer}/{engagement}")
     @Produces("application/json")
     void deleteEngagement(@PathParam("customer") String customer, @PathParam("engagement") String engagement);
-    
+
     @GET
     @Path("/api/v1/config")
     @Produces("application/json")

--- a/src/main/java/com/redhat/labs/lodestar/service/ActiveGitSyncService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ActiveGitSyncService.java
@@ -108,7 +108,7 @@ public class ActiveGitSyncService {
         // sync mongo with git if no engagements found in mongo
         if (active) {
 
-            eventBus.sendAndForget(EventType.REFRESH_DATABASE_EVENT_ADDRESS, EventType.REFRESH_DATABASE_EVENT_ADDRESS);
+            eventBus.sendAndForget(EventType.LOAD_DATABASE_EVENT_ADDRESS, EventType.LOAD_DATABASE_EVENT_ADDRESS);
 
         }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -586,7 +586,7 @@ public class EngagementService {
      * Used by the {@link GitSyncService} to delete all {@link Engagement} from the
      * data store before re-populating from Git.
      */
-    void deleteAll() {
+    public void deleteAll() {
         repository.deleteAll();
     }
 
@@ -785,7 +785,7 @@ public class EngagementService {
      * 
      * @param engagement
      */
-    boolean persistEngagementIfNotFound(Engagement engagement) {
+    public boolean persistEngagementIfNotFound(Engagement engagement) {
 
         if (getByIdOrName(engagement).isEmpty()) {
 
@@ -801,15 +801,6 @@ public class EngagementService {
 
         return false;
 
-    }
-
-    /**
-     * Returns a {@link List} of {@link Engagement} where {@link FileAction} is set.
-     * 
-     * @return
-     */
-    List<Engagement> getModifiedEngagements() {
-        return repository.findByModified();
     }
 
     /**

--- a/src/main/java/com/redhat/labs/lodestar/service/EventService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EventService.java
@@ -1,10 +1,15 @@
 package com.redhat.labs.lodestar.service;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import javax.inject.Inject;
+import javax.json.bind.Jsonb;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -12,8 +17,10 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.redhat.labs.lodestar.model.Commit;
 import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.EngagementUser;
+import com.redhat.labs.lodestar.model.Status;
 import com.redhat.labs.lodestar.model.event.EventType;
 import com.redhat.labs.lodestar.model.event.RetriableEvent;
 import com.redhat.labs.lodestar.model.event.RetriableEvent.RetriableEventBuilder;
@@ -26,6 +33,8 @@ public class EventService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventService.class);
 
+    private static final String LAST_PAGE_HEADER = "x-last-page";
+
     @ConfigProperty(name = "event.max.retries", defaultValue = "-1")
     Integer eventMaxRetries;
 
@@ -34,6 +43,9 @@ public class EventService {
 
     @ConfigProperty(name = "event.retry.max.delay", defaultValue = "60")
     Integer eventRetryMaxDelay;
+
+    @ConfigProperty(name = "get.engagement.per.page", defaultValue = "20")
+    Integer engagementPerPage;
 
     @Inject
     @RestClient
@@ -44,6 +56,9 @@ public class EventService {
 
     @Inject
     EventBus eventBus;
+
+    @Inject
+    Jsonb jsonb;
 
     /**
      * Wraps the {@link Engagement} in a {@link RetriableEvent} and starts
@@ -79,17 +94,6 @@ public class EventService {
     void consumeDeleteEngagementEvent(Engagement engagement) {
         RetriableEvent event = buildRetriableEvent(engagement);
         deleteEngagement(event);
-    }
-
-    /**
-     * Starts the process of inserting any {@link Engagement}s in Git that are not
-     * in the database. Existing {@link Engagement}s will not be udpated.
-     * 
-     * @param event
-     */
-    @ConsumeEvent(value = EventType.REFRESH_DATABASE_EVENT_ADDRESS, blocking = true)
-    void consumeRefreshDatabaseEvent(String event) {
-        engagementService.syncGitToDatabase(false);
     }
 
     /**
@@ -283,6 +287,200 @@ public class EventService {
         }
 
         return builder.build();
+
+    }
+
+    /**
+     * Retrieves the last page number from header of the {@link Response}.
+     * 
+     * @param response
+     * @return
+     */
+    private Integer getNumberOfPages(Response response) {
+
+        String lastPage = response.getHeaderString(LAST_PAGE_HEADER);
+        return lastPage == null ? 1 : Integer.valueOf(lastPage);
+
+    }
+
+    /**
+     * Reads the {@link List} of {@link Engagement}s from the {@link Response}
+     * entity.
+     * 
+     * @param response
+     * @return
+     */
+    private List<Engagement> getEngagementsFromResponse(Response response) {
+
+        return response.readEntity(new GenericType<List<Engagement>>() {
+        });
+
+    }
+
+    /*
+     * Retrieves the first page of {@link Engagement}s from the Git API. Then,
+     * creates a GET_PAGE_OF_ENGAGEMENTS_EVENT for each remaining page of results.
+     */
+    private void getEngagements() {
+LOGGER.debug("get engagements called");
+        // get first page of engagements
+        Response response = getPageOfEngagements(1);
+
+        // process first page of engagements
+        // convert to json for event bus
+        String json = jsonb.toJson(getEngagementsFromResponse(response));
+
+        // send engagements for processing
+        eventBus.sendAndForget(EventType.PERSIST_ENGAGEMENT_LIST_EVENT_ADDRESS, json);
+
+        // get total number of pages from response
+        Integer totalPages = getNumberOfPages(response);
+        LOGGER.trace("found {} total pages.", totalPages);
+
+        // close response
+        response.close();
+
+        if (totalPages > 1) {
+
+            IntStream.range(2, totalPages + 1)
+                    .forEach(i -> eventBus.sendAndForget(EventType.GET_PAGE_OF_ENGAGEMENTS_EVENT_ADDRESS, i));
+
+        }
+
+    }
+
+    /**
+     * Returns the Response from the Git API for the provided page number.
+     * 
+     * @param page
+     * @return
+     */
+    private Response getPageOfEngagements(Integer page) {
+
+        LOGGER.trace("getting page {} of engagements from git api.", page);
+
+        // get page of engagements from git api
+        return gitApiClient.getEngagments(true, page, engagementPerPage, false, false);
+
+    }
+
+    /**
+     * Starts the process of inserting any {@link Engagement}s in Git that are not
+     * in the database. Existing {@link Engagement}s will not be updated.
+     * 
+     * @param event
+     */
+    @ConsumeEvent(value = EventType.LOAD_DATABASE_EVENT_ADDRESS, blocking = true)
+    void consumeLoadDatabaseEvent(String event) {
+
+        // load all engagements from gitlab
+        getEngagements();
+
+    }
+
+    /**
+     * Starts the process of inserting all {@link Engagement}s in Git. All
+     * {@link Engagement}s are removed from the database before inserting.
+     * 
+     * @param event
+     */
+    @ConsumeEvent(value = EventType.DELETE_AND_RELOAD_DATABASE_EVENT_ADDRESS, blocking = true)
+    void consumeDeleteAndReLoadDatabaseEvent(String event) {
+
+        // delete all
+        engagementService.deleteAll();
+        LOGGER.debug("cleared engagements from database.");
+
+        // reload all engagements from gitlab
+        getEngagements();
+
+    }
+
+    /**
+     * Get all {@link Engagement}s for the specified page and send event to process
+     * each one.
+     * 
+     * @param pageNumber
+     */
+    @ConsumeEvent(value = EventType.GET_PAGE_OF_ENGAGEMENTS_EVENT_ADDRESS, blocking = true)
+    void consumeGetPageEvent(Integer pageNumber) {
+
+        // get given page of engagements
+        Response response = getPageOfEngagements(pageNumber);
+        // pull engagements list from response
+        List<Engagement> engagements = getEngagementsFromResponse(response);
+        // close after using
+        response.close();
+
+        // convert to json for event bus
+        String json = jsonb.toJson(engagements);
+
+        // send engagements for processing
+        eventBus.sendAndForget(EventType.PERSIST_ENGAGEMENT_LIST_EVENT_ADDRESS, json);
+
+    }
+
+    /**
+     * Creates a PERSIST_ENGAGEMENT_EVENT for each {@link Engagement} in the
+     * provided {@link List}.
+     * 
+     * @param engagements
+     */
+    @ConsumeEvent(value = EventType.PERSIST_ENGAGEMENT_LIST_EVENT_ADDRESS)
+    void consumeProcessEngagementList(String engagementsJson) {
+
+        // unmarshal
+        Engagement[] engagements = jsonb.fromJson(engagementsJson, Engagement[].class);
+        // create event for each engagement
+        Arrays.stream(engagements).forEach(e -> eventBus.sendAndForget(EventType.PERSIST_ENGAGEMENT_EVENT_ADDRESS, e));
+
+    }
+
+    /**
+     * Persists the {@link Engagement} in the database if it does not already exist.
+     * 
+     * @param engagement
+     */
+    @ConsumeEvent(value = EventType.PERSIST_ENGAGEMENT_EVENT_ADDRESS)
+    void consumeInsertIfMissingEvent(Engagement engagement) {
+
+        if (engagementService.persistEngagementIfNotFound(engagement)) {
+            eventBus.sendAndForget(EventType.UPDATE_STATUS_EVENT_ADDRESS, engagement);
+            eventBus.sendAndForget(EventType.UPDATE_COMMITS_EVENT_ADDRESS, engagement);
+        }
+
+    }
+
+    /**
+     * Retrieves the {@link List} of {@link Commit}s for the given
+     * {@link Engagement} from the Git API and then updates the database.
+     * 
+     * @param engagement
+     */
+    @ConsumeEvent(value = EventType.UPDATE_COMMITS_EVENT_ADDRESS, blocking = true)
+    void consumeUpdateCommitsEvent(Engagement engagement) {
+
+        List<Commit> commits = gitApiClient.getCommits(engagement.getCustomerName(), engagement.getProjectName());
+        engagementService.setCommits(engagement.getUuid(), commits);
+
+    }
+
+    /**
+     * Retrieves the {@link Status} for the given {@link Engagement} from the Git
+     * API and then updates the database.
+     * 
+     * @param engagement
+     */
+    @ConsumeEvent(value = EventType.UPDATE_STATUS_EVENT_ADDRESS, blocking = true)
+    void consumeUpdateStatusEvent(Engagement engagement) {
+
+        try {
+            Status status = gitApiClient.getStatus(engagement.getCustomerName(), engagement.getProjectName());
+            engagementService.setStatus(engagement.getUuid(), status);
+        } catch (WebApplicationException wae) {
+            LOGGER.trace("no status found for engagement {}:{}:{}", engagement.getUuid(), engagement.getCustomerName(),
+                    engagement.getProjectName());
+        }
 
     }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/EventService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EventService.java
@@ -322,7 +322,7 @@ public class EventService {
      * creates a GET_PAGE_OF_ENGAGEMENTS_EVENT for each remaining page of results.
      */
     private void getEngagements() {
-LOGGER.debug("get engagements called");
+
         // get first page of engagements
         Response response = getPageOfEngagements(1);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 quarkus.log.level=INFO
 quarkus.log.category."io.smallrye.jwt".level=${JWT_LOGGING:INFO}
 quarkus.log.category."com.redhat.labs.lodestar".level=${LODESTAR_BACKEND_LOGGING:DEBUG}
+quarkus.log.category."com.redhat.labs.lodestar".min-level=${LODESTAR_BACKEND_MIN_LOGGING:DEBUG}
 
 # open api
 quarkus.swagger-ui.always-include=true
@@ -74,3 +75,5 @@ auto.repopulate.cron.expr=${AUTO_REPOP_CRON:0 0/5 * * * ?}
 event.max.retries=${EVENT_MAX_RETRIES:-1}
 event.retry.delay.factor=${EVENT_RETRY_DELAY_FACTOR:2}
 event.retry.max.delay=${EVENT_RETRY_MAX_DELAY:60}
+# event get engagements per page setting
+get.engagement.per.page=${EVENT_GET_PER_PAGE:20}

--- a/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceUpdateTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceUpdateTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-import com.google.common.collect.Lists;
 import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.EngagementUser;
 import com.redhat.labs.lodestar.model.Launch;
@@ -317,10 +316,6 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         HashMap<String, Long> timeClaims = new HashMap<>();
         String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
 
-        Engagement e = MockUtils.mockMinimumEngagement("c1", "e2", "1234");
-        Mockito.when(gitApiClient.getEngagments()).thenReturn(Lists.newArrayList(e));
-        Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.empty());
-
         given()
             .auth()
             .oauth2(token)
@@ -330,9 +325,6 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         .then()
             .statusCode(202);
 
-        Mockito.verify(eRepository).deleteAll();
-        Mockito.verify(eRepository).persist(Mockito.anyIterable());
-
     }
 
     @Test
@@ -340,10 +332,6 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
 
         HashMap<String, Long> timeClaims = new HashMap<>();
         String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
-
-        Engagement e = MockUtils.mockMinimumEngagement("c1", "e2", "1234");
-        Mockito.when(gitApiClient.getEngagments()).thenReturn(Lists.newArrayList(e));
-        Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.empty());
 
         given()
             .auth()
@@ -353,9 +341,6 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
             .put("/engagements/refresh")
         .then()
             .statusCode(202);
-
-        Mockito.verify(eRepository, Mockito.times(0)).deleteAll();
-        Mockito.verify(eRepository).persist(Mockito.anyIterable());
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/resource/StatusResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/StatusResourceTest.java
@@ -46,8 +46,8 @@ class StatusResourceTest extends IntegrationTestHelper {
         .then()
             .statusCode(200);
 
-        Mockito.verify(gitApiClient).getStatus("jello", "exists");
-        Mockito.verify(gitApiClient).getCommits("jello", "exists");
+        Mockito.verify(gitApiClient, Mockito.timeout(1000)).getStatus("jello", "exists");
+        Mockito.verify(gitApiClient, Mockito.timeout(1000)).getCommits("jello", "exists");
 
     } 
     

--- a/src/test/java/com/redhat/labs/lodestar/resource/StatusResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/StatusResourceTest.java
@@ -69,7 +69,7 @@ class StatusResourceTest extends IntegrationTestHelper {
             .statusCode(200);
 
         Mockito.verify(gitApiClient, Mockito.times(0)).getStatus("jello", "exists");
-        Mockito.verify(gitApiClient).getCommits("jello", "exists");
+        Mockito.verify(gitApiClient, Mockito.timeout(1000)).getCommits("jello", "exists");
 
     } 
 

--- a/src/test/java/com/redhat/labs/lodestar/resource/StatusResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/StatusResourceTest.java
@@ -48,7 +48,6 @@ class StatusResourceTest extends IntegrationTestHelper {
 
         Mockito.verify(gitApiClient).getStatus("jello", "exists");
         Mockito.verify(gitApiClient).getCommits("jello", "exists");
-        Mockito.verify(eRepository).update(Mockito.any(Engagement.class));
 
     } 
     
@@ -71,7 +70,6 @@ class StatusResourceTest extends IntegrationTestHelper {
 
         Mockito.verify(gitApiClient, Mockito.times(0)).getStatus("jello", "exists");
         Mockito.verify(gitApiClient).getCommits("jello", "exists");
-        Mockito.verify(eRepository).update(Mockito.any(Engagement.class));
 
     } 
 

--- a/src/test/java/com/redhat/labs/lodestar/service/ActiveGitSyncServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/ActiveGitSyncServiceTest.java
@@ -108,7 +108,7 @@ class ActiveGitSyncServiceTest {
         service.repopulateDbIfEmpty();
 
         Mockito.verify(eventBus,
-                Mockito.times(0)).sendAndForget(Mockito.eq(EventType.REFRESH_DATABASE_EVENT_ADDRESS), Mockito.any());
+                Mockito.times(0)).sendAndForget(Mockito.eq(EventType.LOAD_DATABASE_EVENT_ADDRESS), Mockito.any());
 
     }
 
@@ -122,7 +122,7 @@ class ActiveGitSyncServiceTest {
 
         service.repopulateDbIfEmpty();
 
-        Mockito.verify(eventBus).sendAndForget(Mockito.eq(EventType.REFRESH_DATABASE_EVENT_ADDRESS), Mockito.any());
+        Mockito.verify(eventBus).sendAndForget(Mockito.eq(EventType.LOAD_DATABASE_EVENT_ADDRESS), Mockito.any());
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
@@ -754,4 +754,30 @@ class EngagementServiceTest {
 
     }
 
+    @Test
+    void testPersistEngagementIfNotFound() {
+
+        Engagement e = MockUtils.mockMinimumEngagement("c1", "p1", "1234");
+        
+        Mockito.when(repository.findByUuid("1234")).thenReturn(Optional.empty());
+
+        assertTrue(service.persistEngagementIfNotFound(e));
+
+        Mockito.verify(repository).persist(Mockito.any(Engagement.class));
+
+    }
+
+    @Test
+    void testPersistEngagementIfNotFoundFound() {
+
+        Engagement e = MockUtils.mockMinimumEngagement("c1", "p1", "1234");
+        
+        Mockito.when(repository.findByUuid("1234")).thenReturn(Optional.of(e));
+
+        assertFalse(service.persistEngagementIfNotFound(e));
+
+        Mockito.verify(repository, Mockito.times(0)).persist(Mockito.any(Engagement.class));
+
+    }
+    
 }

--- a/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
@@ -2,16 +2,19 @@ package com.redhat.labs.lodestar.service;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.redhat.labs.lodestar.model.Engagement;
+import com.redhat.labs.lodestar.model.Status;
 import com.redhat.labs.lodestar.model.event.EventType;
 import com.redhat.labs.lodestar.utils.IntegrationTestHelper;
 
@@ -25,6 +28,9 @@ class EventServiceTest extends IntegrationTestHelper {
 
     @InjectMock
     EngagementService engagementService;
+
+    @Inject
+    EventService eventService;
 
     @Inject
     EventBus eventBus;
@@ -146,7 +152,8 @@ class EventServiceTest extends IntegrationTestHelper {
 
         Mockito.when(gitApiClient.createOrUpdateEngagement(Mockito.any(), Mockito.anyString(), Mockito.anyString()))
                 .thenThrow(new WebApplicationException(500)).thenReturn(created);
-        Mockito.when(engagementService.getByUuid(Mockito.anyString(), Mockito.any())).thenThrow(new WebApplicationException(404));
+        Mockito.when(engagementService.getByUuid(Mockito.anyString(), Mockito.any()))
+                .thenThrow(new WebApplicationException(404));
 
         eventBus.sendAndForget(EventType.UPDATE_ENGAGEMENT_EVENT_ADDRESS, e);
 
@@ -193,6 +200,73 @@ class EventServiceTest extends IntegrationTestHelper {
         eventBus.sendAndForget(EventType.DELETE_ENGAGEMENT_EVENT_ADDRESS, e);
 
         Mockito.verify(gitApiClient, Mockito.timeout(2000).times(2)).deleteEngagement("c1", "p1");
+
+    }
+
+    @Test
+    void testConsumeLoadDatabaseEvent() {
+
+        // set engagements per page to 1
+        eventService.engagementPerPage = 1;
+
+        // list of engagements for page 1
+        Engagement e1 = Engagement.builder().uuid("1111").customerName("c1").projectName("p1").build();
+        List<Engagement> l1 = Lists.newArrayList(e1);
+        // list of engagements for page 2
+        Engagement e2 = Engagement.builder().uuid("2222").customerName("c2").projectName("p2").build();
+        List<Engagement> l2 = Lists.newArrayList(e2);
+
+        Response r1 = Response.ok(l1).header("x-last-page", 2).build();
+        Response r2 = Response.ok(l2).header("x-last-page", 2).build();
+
+        Status status = Status.builder().status("green").build();
+
+        Mockito.when(gitApiClient.getEngagments(Mockito.eq(true), Mockito.anyInt(), Mockito.eq(1), Mockito.eq(false),
+                Mockito.eq(false))).thenReturn(r1, r2);
+
+        Mockito.when(engagementService.persistEngagementIfNotFound(Mockito.any())).thenReturn(true);
+        Mockito.when(gitApiClient.getCommits(Mockito.anyString(), Mockito.anyString())).thenReturn(Lists.newArrayList());
+        Mockito.when(gitApiClient.getStatus(Mockito.anyString(), Mockito.anyString())).thenReturn(status);
+
+        // send load db event
+        eventBus.sendAndForget(EventType.LOAD_DATABASE_EVENT_ADDRESS, EventType.LOAD_DATABASE_EVENT_ADDRESS);
+
+        Mockito.verify(engagementService, Mockito.timeout(1000).times(2)).setCommits(Mockito.anyString(), Mockito.anyList());
+        Mockito.verify(engagementService, Mockito.timeout(1000).times(2)).setStatus(Mockito.anyString(), Mockito.any(Status.class));
+
+    }
+
+    @Test
+    void testConsumeDeleteAndReLoadDatabaseEvent() {
+
+        // set engagements per page to 1
+        eventService.engagementPerPage = 1;
+
+        // list of engagements for page 1
+        Engagement e1 = Engagement.builder().uuid("1111").customerName("c1").projectName("p1").build();
+        List<Engagement> l1 = Lists.newArrayList(e1);
+        // list of engagements for page 2
+        Engagement e2 = Engagement.builder().uuid("2222").customerName("c2").projectName("p2").build();
+        List<Engagement> l2 = Lists.newArrayList(e2);
+
+        Response r1 = Response.ok(l1).header("x-last-page", 2).build();
+        Response r2 = Response.ok(l2).header("x-last-page", 2).build();
+
+        Status status = Status.builder().status("green").build();
+
+        Mockito.when(gitApiClient.getEngagments(Mockito.eq(true), Mockito.anyInt(), Mockito.eq(1), Mockito.eq(false),
+                Mockito.eq(false))).thenReturn(r1, r2);
+
+        Mockito.when(engagementService.persistEngagementIfNotFound(Mockito.any())).thenReturn(true);
+        Mockito.when(gitApiClient.getCommits(Mockito.anyString(), Mockito.anyString())).thenReturn(Lists.newArrayList());
+        Mockito.when(gitApiClient.getStatus(Mockito.anyString(), Mockito.anyString())).thenReturn(status);
+
+        // send load db event
+        eventBus.sendAndForget(EventType.DELETE_AND_RELOAD_DATABASE_EVENT_ADDRESS, EventType.LOAD_DATABASE_EVENT_ADDRESS);
+
+        Mockito.verify(engagementService).deleteAll();
+        Mockito.verify(engagementService, Mockito.timeout(1000).times(2)).setCommits(Mockito.anyString(), Mockito.anyList());
+        Mockito.verify(engagementService, Mockito.timeout(1000).times(2)).setStatus(Mockito.anyString(), Mockito.any(Status.class));
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
@@ -264,7 +264,7 @@ class EventServiceTest extends IntegrationTestHelper {
         // send load db event
         eventBus.sendAndForget(EventType.DELETE_AND_RELOAD_DATABASE_EVENT_ADDRESS, EventType.LOAD_DATABASE_EVENT_ADDRESS);
 
-        Mockito.verify(engagementService).deleteAll();
+        Mockito.verify(engagementService, Mockito.timeout(1000)).deleteAll();
         Mockito.verify(engagementService, Mockito.timeout(1000).times(2)).setCommits(Mockito.anyString(), Mockito.anyList());
         Mockito.verify(engagementService, Mockito.timeout(1000).times(2)).setStatus(Mockito.anyString(), Mockito.any(Status.class));
 


### PR DESCRIPTION
- Added Events to help facilitate populating/repopulating mongo with engagements from GitLab
  - The get all engagements is now broken down into pages and without status and commit information so smaller amounts are retrieved from git-api
  - Each returned engagement is inserted into mongo if it does not already exist
  - Status and Commit information are only retrieved if inserting into mongo.  This is done asynchronously.
- Update Status and Commit Webhook now uses the same async functionality
- Refresh Database API also uses the same mechanism to populate the data
  - `purgeFirst` is still available on this api
- BugFix
  - allow no body in Git API REST error response 