### PR TITLE
Allow engagement refresh from webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ The following environment variables are available:
 | WEBHOOK_TOKEN | myToken | True |
 | CLEANUP_TOKEN | cToken | False |
 
+### Engagements Resource
+
+| Name | Example Value | Required |
+|------|---------------|----------|
+| COMMIT_FILTERED_MESSAGE_LIST | manual_refresh | False |
+
 ### Git Database Sync
 
 | Name | Example Value | Required |

--- a/src/main/java/com/redhat/labs/lodestar/model/Hook.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Hook.java
@@ -15,25 +15,26 @@ public class Hook {
 
     private String objectKind;
     private String eventName;
+    private Integer projectId;
     private List<Commit> commits;
     private GitlabProject project;
     private String groupId;
-    
+
     public boolean didFileChange(String fileName) {
-        for(Commit commit : commits) {
-            if(commit.didFileChange(fileName)) {
-                return true;    
+        for (Commit commit : commits) {
+            if (commit.didFileChange(fileName)) {
+                return true;
             }
         }
-        
+
         return false;
     }
-    
+
     public String getCustomerName() {
         return project.getCustomerNameFromName();
-        
+
     }
-    
+
     public String getEngagementName() {
         return project.getEngagementNameFromName();
     }
@@ -41,5 +42,9 @@ public class Hook {
     public boolean wasProjectDeleted() {
         return "project_deleted".equals(eventName);
     }
-    
+
+    public boolean refreshEngagement() {
+        return commits.stream().anyMatch(c -> "manual_refresh".equalsIgnoreCase(c.getMessage()));
+    }
+
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/Hook.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Hook.java
@@ -43,8 +43,8 @@ public class Hook {
         return "project_deleted".equals(eventName);
     }
 
-    public boolean refreshEngagement() {
-        return commits.stream().anyMatch(c -> "manual_refresh".equalsIgnoreCase(c.getMessage()));
+    public boolean containsAnyMessage(List<String> messages) {
+        return messages.stream().anyMatch(message -> commits.stream().anyMatch(c -> message.equals(c.getMessage())));
     }
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -470,6 +470,13 @@ public class EngagementService {
     public void updateStatusAndCommits(Hook hook) {
         LOGGER.debug("Hook for {} {}", hook.getCustomerName(), hook.getEngagementName());
 
+        // refresh entire engagement if requested
+        if(hook.refreshEngagement()) {
+            LOGGER.debug("hook triggered refresh of engagement for project {}", hook.getProjectId());
+            syncGitToDatabase(false, null, String.valueOf(hook.getProjectId()));
+            return;
+        }
+
         // create engagement for get
         Engagement search = Engagement.builder().customerName(hook.getCustomerName())
                 .projectName(hook.getEngagementName()).build();

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -50,6 +50,9 @@ public class EngagementService {
     @ConfigProperty(name = "status.file")
     String statusFile;
 
+    @ConfigProperty(name = "commit.msg.filter.list", defaultValue = "not.set")
+    List<String> commitFilteredMessages;
+
     @Inject
     Jsonb jsonb;
 
@@ -471,7 +474,7 @@ public class EngagementService {
         LOGGER.debug("Hook for {} {}", hook.getCustomerName(), hook.getEngagementName());
 
         // refresh entire engagement if requested
-        if(hook.refreshEngagement()) {
+        if(hook.containsAnyMessage(commitFilteredMessages)) {
             LOGGER.debug("hook triggered refresh of engagement for project {}", hook.getProjectId());
             syncGitToDatabase(false, null, String.valueOf(hook.getProjectId()));
             return;

--- a/src/main/java/com/redhat/labs/lodestar/service/EventService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EventService.java
@@ -375,7 +375,7 @@ public class EventService {
         if (null != projectId) {
 
             // get engagement by project id from git api
-            Engagement found = gitApiClient.getEngagementByNamespace(String.valueOf(projectId));
+            Engagement found = gitApiClient.getEngagementByNamespace(projectId);
 
             if(null != found) {
                 // send event to delete existing engagement from database
@@ -395,8 +395,8 @@ public class EventService {
     void consumeDeleteEngagementFromDatabaseEvent(Engagement engagement) {
 
         try {
-        // remove existing engagement from database
-        engagementService.deleteByUuid(engagement.getUuid());
+            // remove existing engagement from database
+            engagementService.deleteByUuid(engagement.getUuid());
         } catch(WebApplicationException wae) {
             LOGGER.info("no engagement found in database with id {}", engagement.getUuid());
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,6 +62,7 @@ lodestar.status.api/mp-rest/url=${LODESTAR_STATUS_API_URL:http://lodestar-status
 webhook.token=${WEBHOOK_TOKEN:t}
 cleanup.token=${CLEANUP_TOKEN:OFF}
 status.file=status.json
+commit.msg.filter.list=${COMMIT_FILTERED_MESSAGE_LIST:manual_refresh}
 
 # version
 git.commit=${LODESTAR_BACKEND_GIT_COMMIT:not.set}

--- a/src/test/java/com/redhat/labs/lodestar/model/HookTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/model/HookTest.java
@@ -1,0 +1,35 @@
+package com.redhat.labs.lodestar.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.gradle.internal.impldep.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+class HookTest {
+
+    @Test
+    void testContainsAnyMessageFound() {
+
+        Commit c1 = Commit.builder().message("message1").build();
+        Commit c2 = Commit.builder().message("message2").build();
+        Commit c3 = Commit.builder().message("message3").build();
+        Hook hook = Hook.builder().commits(Lists.newArrayList(c1, c2, c3)).build();
+
+        assertTrue(hook.containsAnyMessage(Lists.newArrayList("message3")));
+
+    }
+
+    @Test
+    void testContainsAnyMessageNotFound() {
+
+        Commit c1 = Commit.builder().message("message1").build();
+        Commit c2 = Commit.builder().message("message2").build();
+        Commit c3 = Commit.builder().message("message3").build();
+        Hook hook = Hook.builder().commits(Lists.newArrayList(c1, c2, c3)).build();
+
+        assertFalse(hook.containsAnyMessage(Lists.newArrayList("message5")));
+
+    }
+
+}

--- a/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EventServiceTest.java
@@ -34,7 +34,7 @@ class EventServiceTest extends IntegrationTestHelper {
 
     @Inject
     EventBus eventBus;
-
+    
     @Test
     void testConsumeCreateEngagementEventSuccess() {
 

--- a/src/test/java/com/redhat/labs/lodestar/utils/MockUtils.java
+++ b/src/test/java/com/redhat/labs/lodestar/utils/MockUtils.java
@@ -56,18 +56,26 @@ public class MockUtils {
     public static Hook mockHook(String pathWithNamespace, String nameWithNamespace, boolean fileChanged,
             String fileName) {
         return Hook.builder().project(mockGitLabProject(pathWithNamespace, nameWithNamespace))
-                .commits(Lists.newArrayList(mockCommit(fileName, fileChanged))).build();
+                .commits(Lists.newArrayList(mockCommit(fileName, fileChanged, null))).build();
+    }
+
+    public static Hook mockHook(String pathWithNamespace, String nameWithNamespace, boolean fileChanged,
+            String fileName, String message) {
+        return Hook.builder().project(mockGitLabProject(pathWithNamespace, nameWithNamespace))
+                .commits(Lists.newArrayList(mockCommit(fileName, fileChanged, message))).build();
     }
 
     public static GitlabProject mockGitLabProject(String pathWithNamespace, String nameWithNamspace) {
         return GitlabProject.builder().pathWithNamespace(pathWithNamespace).nameWithNamespace(nameWithNamspace).build();
     }
 
-    public static Commit mockCommit(String fileName, boolean hasChanged) {
+    public static Commit mockCommit(String fileName, boolean hasChanged, String message) {
         CommitBuilder builder = Commit.builder();
         if (hasChanged) {
             builder.added(Lists.newArrayList("status.json"));
         }
+        String msg = (null == message) ? "message for commit" : "manual_refresh";
+        builder.message(msg);
         return builder.build();
     }
 


### PR DESCRIPTION
- Allows the refresh of an engagement by using a GitLab push event to trigger the `backend` status hook endpoint.
- If the list of commits sent in the body of the webhook call contains a configured message, the engagement will be reloaded into the database. 
  - default configured message is `manual_refresh`
  - can be configured by environment variable `COMMIT_FILTERED_MESSAGE_LIST`
- If the commit list does not contain the message, it behaves the same way it always has.   If status.json was changed, the status will be updated in the database and the commits will be updated.  no other fields will be updated.