### PR TITLE
Refresh from Hook Should not use Equals

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/model/Hook.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Hook.java
@@ -44,7 +44,8 @@ public class Hook {
     }
 
     public boolean containsAnyMessage(List<String> messages) {
-        return messages.stream().anyMatch(message -> commits.stream().anyMatch(c -> c.getMessage().startsWith(message)));
+        return messages.stream().anyMatch(message -> commits.stream()
+                .anyMatch(c -> null != c.getMessage() && c.getMessage().startsWith(message)));
     }
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/Hook.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Hook.java
@@ -44,7 +44,7 @@ public class Hook {
     }
 
     public boolean containsAnyMessage(List<String> messages) {
-        return messages.stream().anyMatch(message -> commits.stream().anyMatch(c -> message.startsWith(c.getMessage())));
+        return messages.stream().anyMatch(message -> commits.stream().anyMatch(c -> c.getMessage().startsWith(message)));
     }
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/Hook.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Hook.java
@@ -44,7 +44,7 @@ public class Hook {
     }
 
     public boolean containsAnyMessage(List<String> messages) {
-        return messages.stream().anyMatch(message -> commits.stream().anyMatch(c -> message.equals(c.getMessage())));
+        return messages.stream().anyMatch(message -> commits.stream().anyMatch(c -> message.startsWith(c.getMessage())));
     }
 
 }

--- a/src/test/java/com/redhat/labs/lodestar/model/HookTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/model/HookTest.java
@@ -11,7 +11,7 @@ class HookTest {
     @Test
     void testContainsAnyMessageFound() {
 
-        Commit c1 = Commit.builder().message("message1").build();
+        Commit c1 = Commit.builder().message(null).build();
         Commit c2 = Commit.builder().message("message2").build();
         Commit c3 = Commit.builder().message("message3").build();
         Hook hook = Hook.builder().commits(Lists.newArrayList(c1, c2, c3)).build();

--- a/src/test/java/com/redhat/labs/lodestar/model/HookTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/model/HookTest.java
@@ -21,6 +21,18 @@ class HookTest {
     }
 
     @Test
+    void testContainsAnyMessageFoundWithExtraText() {
+
+        Commit c1 = Commit.builder().message("message1").build();
+        Commit c2 = Commit.builder().message("message2").build();
+        Commit c3 = Commit.builder().message("message3 updated some value").build();
+        Hook hook = Hook.builder().commits(Lists.newArrayList(c1, c2, c3)).build();
+
+        assertTrue(hook.containsAnyMessage(Lists.newArrayList("message3")));
+
+    }
+
+    @Test
     void testContainsAnyMessageNotFound() {
 
         Commit c1 = Commit.builder().message("message1").build();


### PR DESCRIPTION
The webhook method checks to see if the commit messages supplied have the configured messages within them. 

This fix make sure it checks that the commit message starts with the configured filtered message(s).  If it starts with the filtered message, the entire engagement will be refreshed in the database.