### PR TITLE
Allow for application roles to be defined at build time

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,13 +15,23 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 13.0.1
+    - name: Find and Replace Reader Writer
+      shell: bash
+      env:
+        READER: ${{ secrets.READERS }}
+        WRITER: ${{ secrets.WRITERS }}
+      run: |
+        sed -i '/^quarkus.http.auth.policy.role-reader.roles-allowed/ s/$/,'"$READER"'/' src/main/resources/application.properties
+        sed -i '/^quarkus.http.auth.policy.role-writer.roles-allowed/ s/$/,'"$WRITER"'/' src/main/resources/application.properties
     - name: SonarCloud Static Analysis
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: mvn verify sonar:sonar -Dsonar.login=${{ secrets.SONAR_TOKEN }} -q
+    - name: Clean sonar
+      run: mvn clean
     - name: Find and Replace Commit
-      uses: jacobtomlinson/gha-find-replace@0.1.1
+      uses: jacobtomlinson/gha-find-replace@0.1.2
       with:
         find: "###GIT_COMMIT###"
         replace: "${{ github.sha }}"


### PR DESCRIPTION
Quarkus requires user roles to be set at runtime. This challenge will allow us to configure those roles at build time while also allowing default roles to be use locally. Essentially, this appends roles to the roles predefined in the code.

application.properties
```
quarkus.http.auth.policy.role-reader.roles-allowed=reader
```

in a gh secret 
```
READERS=some-other-role,avid-reader
```

after build time

```
quarkus.http.auth.policy.role-reader.roles-allowed=reader,some-other-role,avid-reader
```

