### PR TITLE
APIs for Artifacts, Use Cases, Scores, Hosting Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ if provided, the specified page will be returned. defaults to 1
 
 ```
 GET /engagements/customers/suggest
+GET /engagements/artifacts
 GET /engagements/artifacts/types
 GET /engagements/categories
+GET /engagements/hosting/environments
+GET /engagements/scores
+GET /engagements/usecases
 ```
 
 The following parameters are supported:

--- a/src/main/java/com/redhat/labs/lodestar/model/Artifact.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Artifact.java
@@ -1,21 +1,23 @@
 package com.redhat.labs.lodestar.model;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder(toBuilder = true)
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Artifact {
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
+public class Artifact extends EngagementAttribute {
 
-    private String id;
     private String title;
     private String description;
     private String type;
     private String linkAddress;
-
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Engagement.java
@@ -1,7 +1,6 @@
 package com.redhat.labs.lodestar.model;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.json.bind.annotation.JsonbProperty;
@@ -98,6 +97,6 @@ public class Engagement extends PanacheMongoEntityBase {
     @JsonbProperty("commit_message")
     private String commitMessage;
 
-    private Map<String, Double> scores;
+    private List<Score> scores;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/EngagementAttribute.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/EngagementAttribute.java
@@ -1,0 +1,46 @@
+package com.redhat.labs.lodestar.model;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@ToString
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EngagementAttribute {
+
+    private String uuid;
+    private String created;
+    private String updated;
+    private String engagementUuid;
+
+    public void generateId() {
+        if (null == uuid) {
+            uuid = UUID.randomUUID().toString();
+        }
+    }
+
+    public void setUpdated() {
+        String dateTime = getNowAsString();
+        updated = dateTime;
+    }
+
+    public void setCreatedAndUpdated() {
+        String dateTime = getNowAsString();
+        created = dateTime;
+        updated = dateTime;
+    }
+
+    private String getNowAsString() {
+        return LocalDateTime.now(ZoneId.of("Z")).toString();
+    }
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/model/HostingEnvironment.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/HostingEnvironment.java
@@ -3,18 +3,19 @@ package com.redhat.labs.lodestar.model;
 import javax.json.bind.annotation.JsonbProperty;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder(toBuilder = true)
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class HostingEnvironment {
-
-    @JsonbProperty("id")
-    private String id;
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
+public class HostingEnvironment extends EngagementAttribute {
 
     @JsonbProperty("environment_name")
     private String environmentName;

--- a/src/main/java/com/redhat/labs/lodestar/model/Score.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/Score.java
@@ -13,10 +13,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = false)
-public class UseCase extends EngagementAttribute {
+public class Score extends EngagementAttribute {
 
-    private String title;
-    private String description;
-    private Integer order;
+    private String name;
+    private Double value;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedArtifactResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedArtifactResults.java
@@ -1,22 +1,12 @@
 package com.redhat.labs.lodestar.model.pagination;
 
-import java.util.List;
-
 import com.redhat.labs.lodestar.model.Artifact;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Data
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class PagedArtifactResults extends PagedResults {
-
-    private List<Artifact> results;
+public class PagedArtifactResults extends PagedResults<Artifact> {
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedCategoryResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedCategoryResults.java
@@ -1,22 +1,12 @@
 package com.redhat.labs.lodestar.model.pagination;
 
-import java.util.List;
-
 import com.redhat.labs.lodestar.model.Category;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Data
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class PagedCategoryResults extends PagedResults {
-
-    private List<Category> results;
+public class PagedCategoryResults extends PagedResults<Category> {
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedEngagementResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedEngagementResults.java
@@ -1,22 +1,12 @@
 package com.redhat.labs.lodestar.model.pagination;
 
-import java.util.List;
-
 import com.redhat.labs.lodestar.model.Engagement;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Data
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class PagedEngagementResults extends PagedResults {
-
-    private List<Engagement> results;
+public class PagedEngagementResults extends PagedResults<Engagement> {
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedHostingEnvironmentResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedHostingEnvironmentResults.java
@@ -1,22 +1,12 @@
 package com.redhat.labs.lodestar.model.pagination;
 
-import java.util.List;
-
 import com.redhat.labs.lodestar.model.HostingEnvironment;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Data
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class PagedHostingEnvironmentResults extends PagedResults {
-   
-    private List<HostingEnvironment> results;
+public class PagedHostingEnvironmentResults extends PagedResults<HostingEnvironment> {
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedHostingEnvironmentResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedHostingEnvironmentResults.java
@@ -1,4 +1,8 @@
-package com.redhat.labs.lodestar.model;
+package com.redhat.labs.lodestar.model.pagination;
+
+import java.util.List;
+
+import com.redhat.labs.lodestar.model.HostingEnvironment;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,9 +15,8 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class Category extends EngagementAttribute {
-
-    private String name;
-    private Integer count;
+public class PagedHostingEnvironmentResults extends PagedResults {
+   
+    private List<HostingEnvironment> results;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedResults.java
@@ -1,5 +1,6 @@
 package com.redhat.labs.lodestar.model.pagination;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PagedResults {
+public class PagedResults<T> {
 
     private static final String CURRENT_PAGE = "page";
     private static final String PER_PAGE = "per_page";
@@ -49,6 +50,9 @@ public class PagedResults {
     private Map<String, Map<String, Integer>> linkHeaders = new HashMap<>();
     @Builder.Default
     private Map<String, Object> headers = new HashMap<>();
+    
+    @Builder.Default
+    private List<T> results = new ArrayList<>();
 
     /**
      * Returns a {@link Map} containing the headers.

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedScoreResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedScoreResults.java
@@ -1,22 +1,12 @@
 package com.redhat.labs.lodestar.model.pagination;
 
-import java.util.List;
-
 import com.redhat.labs.lodestar.model.Score;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Data
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class PagedScoreResults extends PagedResults {
-
-    private List<Score> results;
+public class PagedScoreResults extends PagedResults<Score> {
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedScoreResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedScoreResults.java
@@ -1,4 +1,8 @@
-package com.redhat.labs.lodestar.model;
+package com.redhat.labs.lodestar.model.pagination;
+
+import java.util.List;
+
+import com.redhat.labs.lodestar.model.Score;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,9 +15,8 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class Category extends EngagementAttribute {
+public class PagedScoreResults extends PagedResults {
 
-    private String name;
-    private Integer count;
+    private List<Score> results;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedStringResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedStringResults.java
@@ -1,20 +1,10 @@
 package com.redhat.labs.lodestar.model.pagination;
 
-import java.util.List;
-
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Data
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class PagedStringResults extends PagedResults {
-
-    private List<String> results;
+public class PagedStringResults extends PagedResults<String> {
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedUseCaseResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedUseCaseResults.java
@@ -1,4 +1,8 @@
-package com.redhat.labs.lodestar.model;
+package com.redhat.labs.lodestar.model.pagination;
+
+import java.util.List;
+
+import com.redhat.labs.lodestar.model.UseCase;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,9 +15,8 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class Category extends EngagementAttribute {
+public class PagedUseCaseResults extends PagedResults {
 
-    private String name;
-    private Integer count;
+    private List<UseCase> results;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedUseCaseResults.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/pagination/PagedUseCaseResults.java
@@ -1,22 +1,12 @@
 package com.redhat.labs.lodestar.model.pagination;
 
-import java.util.List;
-
 import com.redhat.labs.lodestar.model.UseCase;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Data
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class PagedUseCaseResults extends PagedResults {
-
-    private List<UseCase> results;
+public class PagedUseCaseResults extends PagedResults<UseCase> {
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/repository/MongoAggregationHelper.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/MongoAggregationHelper.java
@@ -195,8 +195,9 @@ public class MongoAggregationHelper {
         // create include fields from fields
         String[] fields = projectFields.get().split(",");
         Bson[] excludeId = new Bson[] { excludeId() };
+        Bson[] engagementUuid = new Bson[] { new BsonDocument("engagementUuid", new BsonString("$uuid")) };
         Bson[] bsonFields = Stream.of(fields).map(MongoAggregationHelper::getUnwindProjectField).toArray(Bson[]::new);
-        Bson[] combined = Stream.of(excludeId, bsonFields).flatMap(Stream::of).toArray(Bson[]::new);
+        Bson[] combined = Stream.of(excludeId, bsonFields, engagementUuid).flatMap(Stream::of).toArray(Bson[]::new);
 
         // project fields after unwind
         pipeline.add(project(fields(combined)));

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementArtifactResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementArtifactResource.java
@@ -1,0 +1,95 @@
+package com.redhat.labs.lodestar.resource;
+
+import java.util.Optional;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+
+import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
+import com.redhat.labs.lodestar.model.pagination.PagedArtifactResults;
+import com.redhat.labs.lodestar.model.pagination.PagedStringResults;
+import com.redhat.labs.lodestar.service.EngagementService;
+
+@RequestScoped
+@Path("/engagements")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@SecurityScheme(securitySchemeName = "jwt", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class EngagementArtifactResource {
+
+    @Inject
+    JsonWebToken jwt;
+
+    @Inject
+    EngagementService engagementService;
+
+    @GET
+    @Path("/artifacts")
+    @SecurityRequirement(name = "jwt", scopes = {})
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "200", description = "Artifacts have been returned.") })
+    @Operation(summary = "Returns artifact list")
+    @Counted(name = "engagement-get-all-artifacts-counted")
+    @Timed(name = "engagement-get-all-artifacts-timer", unit = MetricUnits.MILLISECONDS)
+    public Response getArtifacts(@Context UriInfo uriInfo,
+            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
+            @BeanParam ListFilterOptions filterOptions) {
+
+        if (suggest.isPresent()) {
+            filterOptions.addLikeSearchCriteria("artifacts.type", suggest.get());
+        }
+
+        PagedArtifactResults page = engagementService.getArtifacts(filterOptions);
+        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+        return builder.build();
+
+    }
+
+    @GET
+    @Path("/artifact/types")
+    @SecurityRequirement(name = "jwt", scopes = {})
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "200", description = "Artifact types have been returned.") })
+    @Operation(summary = "Returns artifact type list")
+    @Counted(name = "engagement-get-all-artifacts-types-counted")
+    @Timed(name = "engagement-get-all-artifacts-types-timer", unit = MetricUnits.MILLISECONDS)
+    public Response getArtifactTypes(@Context UriInfo uriInfo,
+            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
+            @BeanParam ListFilterOptions filterOptions) {
+
+        if (suggest.isPresent()) {
+            filterOptions.addLikeSearchCriteria("artifacts.type", suggest.get());
+        }
+
+        PagedStringResults page = engagementService.getArtifactTypes(filterOptions);
+        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+        return builder.build();
+
+    }
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementCategoryResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementCategoryResource.java
@@ -1,0 +1,71 @@
+package com.redhat.labs.lodestar.resource;
+
+import java.util.Optional;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+
+import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
+import com.redhat.labs.lodestar.model.pagination.PagedCategoryResults;
+import com.redhat.labs.lodestar.service.EngagementService;
+
+@RequestScoped
+@Path("/engagements")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@SecurityScheme(securitySchemeName = "jwt", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class EngagementCategoryResource {
+
+    @Inject
+    JsonWebToken jwt;
+
+    @Inject
+    EngagementService engagementService;
+    
+    @GET
+    @Path("/categories")
+    @SecurityRequirement(name = "jwt", scopes = {})
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "200", description = "Customer data has been returned.") })
+    @Operation(summary = "Returns customers list")
+    @Counted(name = "engagement-get-all-categories-counted")
+    @Timed(name = "engagement-get-all-categories-timer", unit = MetricUnits.MILLISECONDS)
+    public Response getAllCategories(@Context UriInfo uriInfo,
+            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
+            @BeanParam ListFilterOptions filterOptions) {
+
+        if (suggest.isPresent()) {
+            filterOptions.addLikeSearchCriteria("categories.name", suggest.get());
+        }
+
+        PagedCategoryResults page = engagementService.getCategories(filterOptions);
+        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+        return builder.build();
+
+    }
+    
+}

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementHostingEnvironmentResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementHostingEnvironmentResource.java
@@ -1,0 +1,61 @@
+package com.redhat.labs.lodestar.resource;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+
+import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
+import com.redhat.labs.lodestar.model.pagination.PagedHostingEnvironmentResults;
+import com.redhat.labs.lodestar.service.EngagementService;
+
+@RequestScoped
+@Path("/engagements")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@SecurityScheme(securitySchemeName = "jwt", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class EngagementHostingEnvironmentResource {
+
+    @Inject
+    JsonWebToken jwt;
+
+    @Inject
+    EngagementService engagementService;
+
+    @GET
+    @Path("/hosting/environments")
+    @SecurityRequirement(name = "jwt", scopes = {})
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "200", description = "hosting environments have been returned.") })
+    @Operation(summary = "Returns engagement hosting environments")
+    @Counted(name = "engagement-get-all-environments-counted")
+    @Timed(name = "engagement-get-all-environments-timer", unit = MetricUnits.MILLISECONDS)
+    public Response getHostingEnvironments(@Context UriInfo uriInfo, @BeanParam ListFilterOptions filterOptions) {
+
+        PagedHostingEnvironmentResults page = engagementService.getHostingEnvironments(filterOptions);
+        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+        return builder.build();
+
+    }
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -41,7 +41,6 @@ import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.EngagementUserSummary;
 import com.redhat.labs.lodestar.model.filter.FilterOptions;
 import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
-import com.redhat.labs.lodestar.model.pagination.PagedCategoryResults;
 import com.redhat.labs.lodestar.model.pagination.PagedEngagementResults;
 import com.redhat.labs.lodestar.model.pagination.PagedStringResults;
 import com.redhat.labs.lodestar.service.EngagementService;
@@ -124,51 +123,51 @@ public class EngagementResource {
 
     }
 
-    @GET
-    @Path("/categories")
-    @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
-            @APIResponse(responseCode = "200", description = "Customer data has been returned.") })
-    @Operation(summary = "Returns customers list")
-    @Counted(name = "engagement-get-all-categories-counted")
-    @Timed(name = "engagement-get-all-categories-timer", unit = MetricUnits.MILLISECONDS)
-    public Response getAllCategories(@Context UriInfo uriInfo,
-            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
-            @BeanParam ListFilterOptions filterOptions) {
+//    @GET
+//    @Path("/categories")
+//    @SecurityRequirement(name = "jwt", scopes = {})
+//    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+//            @APIResponse(responseCode = "200", description = "Customer data has been returned.") })
+//    @Operation(summary = "Returns customers list")
+//    @Counted(name = "engagement-get-all-categories-counted")
+//    @Timed(name = "engagement-get-all-categories-timer", unit = MetricUnits.MILLISECONDS)
+//    public Response getAllCategories(@Context UriInfo uriInfo,
+//            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
+//            @BeanParam ListFilterOptions filterOptions) {
+//
+//        if (suggest.isPresent()) {
+//            filterOptions.addLikeSearchCriteria("categories.name", suggest.get());
+//        }
+//
+//        PagedCategoryResults page = engagementService.getCategories(filterOptions);
+//        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+//        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+//        return builder.build();
+//
+//    }
 
-        if (suggest.isPresent()) {
-            filterOptions.addLikeSearchCriteria("categories.name", suggest.get());
-        }
-
-        PagedCategoryResults page = engagementService.getCategories(filterOptions);
-        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
-        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
-        return builder.build();
-
-    }
-
-    @GET
-    @Path("/artifact/types")
-    @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
-            @APIResponse(responseCode = "200", description = "Artifact types have been returned.") })
-    @Operation(summary = "Returns artifact type list")
-    @Counted(name = "engagement-get-all-artifacts-counted")
-    @Timed(name = "engagement-get-all-artifacts-timer", unit = MetricUnits.MILLISECONDS)
-    public Response getArtifactTypes(@Context UriInfo uriInfo,
-            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
-            @BeanParam ListFilterOptions filterOptions) {
-
-        if (suggest.isPresent()) {
-            filterOptions.addLikeSearchCriteria("artifacts.type", suggest.get());
-        }
-
-        PagedStringResults page = engagementService.getArtifactTypes(filterOptions);
-        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
-        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
-        return builder.build();
-
-    }
+//    @GET
+//    @Path("/artifact/types")
+//    @SecurityRequirement(name = "jwt", scopes = {})
+//    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+//            @APIResponse(responseCode = "200", description = "Artifact types have been returned.") })
+//    @Operation(summary = "Returns artifact type list")
+//    @Counted(name = "engagement-get-all-artifacts-counted")
+//    @Timed(name = "engagement-get-all-artifacts-timer", unit = MetricUnits.MILLISECONDS)
+//    public Response getArtifactTypes(@Context UriInfo uriInfo,
+//            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
+//            @BeanParam ListFilterOptions filterOptions) {
+//
+//        if (suggest.isPresent()) {
+//            filterOptions.addLikeSearchCriteria("artifacts.type", suggest.get());
+//        }
+//
+//        PagedStringResults page = engagementService.getArtifactTypes(filterOptions);
+//        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+//        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+//        return builder.build();
+//
+//    }
 
     /*
      * GET SINGLE

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -123,52 +123,6 @@ public class EngagementResource {
 
     }
 
-//    @GET
-//    @Path("/categories")
-//    @SecurityRequirement(name = "jwt", scopes = {})
-//    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
-//            @APIResponse(responseCode = "200", description = "Customer data has been returned.") })
-//    @Operation(summary = "Returns customers list")
-//    @Counted(name = "engagement-get-all-categories-counted")
-//    @Timed(name = "engagement-get-all-categories-timer", unit = MetricUnits.MILLISECONDS)
-//    public Response getAllCategories(@Context UriInfo uriInfo,
-//            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
-//            @BeanParam ListFilterOptions filterOptions) {
-//
-//        if (suggest.isPresent()) {
-//            filterOptions.addLikeSearchCriteria("categories.name", suggest.get());
-//        }
-//
-//        PagedCategoryResults page = engagementService.getCategories(filterOptions);
-//        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
-//        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
-//        return builder.build();
-//
-//    }
-
-//    @GET
-//    @Path("/artifact/types")
-//    @SecurityRequirement(name = "jwt", scopes = {})
-//    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
-//            @APIResponse(responseCode = "200", description = "Artifact types have been returned.") })
-//    @Operation(summary = "Returns artifact type list")
-//    @Counted(name = "engagement-get-all-artifacts-counted")
-//    @Timed(name = "engagement-get-all-artifacts-timer", unit = MetricUnits.MILLISECONDS)
-//    public Response getArtifactTypes(@Context UriInfo uriInfo,
-//            @Parameter(name = "suggest", deprecated = true, required = false, description = "uses suggestion as case insensitive search string") @QueryParam("suggest") Optional<String> suggest,
-//            @BeanParam ListFilterOptions filterOptions) {
-//
-//        if (suggest.isPresent()) {
-//            filterOptions.addLikeSearchCriteria("artifacts.type", suggest.get());
-//        }
-//
-//        PagedStringResults page = engagementService.getArtifactTypes(filterOptions);
-//        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
-//        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
-//        return builder.build();
-//
-//    }
-
     /*
      * GET SINGLE
      */

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementScoreResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementScoreResource.java
@@ -1,0 +1,61 @@
+package com.redhat.labs.lodestar.resource;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+
+import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
+import com.redhat.labs.lodestar.model.pagination.PagedScoreResults;
+import com.redhat.labs.lodestar.service.EngagementService;
+
+@RequestScoped
+@Path("/engagements")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@SecurityScheme(securitySchemeName = "jwt", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class EngagementScoreResource {
+
+    @Inject
+    JsonWebToken jwt;
+
+    @Inject
+    EngagementService engagementService;
+
+    @GET
+    @Path("/scores")
+    @SecurityRequirement(name = "jwt", scopes = {})
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "200", description = "scores have been returned.") })
+    @Operation(summary = "Returns engagement scores")
+    @Counted(name = "engagement-get-all-scores-counted")
+    @Timed(name = "engagement-get-all-scores-timer", unit = MetricUnits.MILLISECONDS)
+    public Response getScores(@Context UriInfo uriInfo, @BeanParam ListFilterOptions filterOptions) {
+
+        PagedScoreResults page = engagementService.getScores(filterOptions);
+        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+        return builder.build();
+
+    }
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementUseCaseResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementUseCaseResource.java
@@ -1,0 +1,61 @@
+package com.redhat.labs.lodestar.resource;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+
+import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
+import com.redhat.labs.lodestar.model.pagination.PagedUseCaseResults;
+import com.redhat.labs.lodestar.service.EngagementService;
+
+@RequestScoped
+@Path("/engagements")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@SecurityScheme(securitySchemeName = "jwt", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class EngagementUseCaseResource {
+
+    @Inject
+    JsonWebToken jwt;
+
+    @Inject
+    EngagementService engagementService;
+
+    @GET
+    @Path("/usecases")
+    @SecurityRequirement(name = "jwt", scopes = {})
+    @APIResponses(value = { @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
+            @APIResponse(responseCode = "200", description = "use cases have been returned.") })
+    @Operation(summary = "Returns engagement use cases")
+    @Counted(name = "engagement-get-all-usecases-counted")
+    @Timed(name = "engagement-get-all-usecases-timer", unit = MetricUnits.MILLISECONDS)
+    public Response getScores(@Context UriInfo uriInfo, @BeanParam ListFilterOptions filterOptions) {
+
+        PagedUseCaseResults page = engagementService.getUseCases(filterOptions);
+        ResponseBuilder builder = Response.ok(page.getResults()).links(page.getLinks(uriInfo.getAbsolutePathBuilder()));
+        page.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+        return builder.build();
+
+    }
+
+}

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -21,22 +21,30 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
 import com.redhat.labs.lodestar.model.Commit;
 import com.redhat.labs.lodestar.model.CreationDetails;
 import com.redhat.labs.lodestar.model.Engagement;
+import com.redhat.labs.lodestar.model.EngagementAttribute;
 import com.redhat.labs.lodestar.model.EngagementUser;
 import com.redhat.labs.lodestar.model.EngagementUserSummary;
 import com.redhat.labs.lodestar.model.Hook;
 import com.redhat.labs.lodestar.model.HostingEnvironment;
 import com.redhat.labs.lodestar.model.Launch;
+import com.redhat.labs.lodestar.model.Score;
 import com.redhat.labs.lodestar.model.Status;
+import com.redhat.labs.lodestar.model.UseCase;
 import com.redhat.labs.lodestar.model.event.EventType;
 import com.redhat.labs.lodestar.model.filter.FilterOptions;
 import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
+import com.redhat.labs.lodestar.model.pagination.PagedArtifactResults;
 import com.redhat.labs.lodestar.model.pagination.PagedCategoryResults;
 import com.redhat.labs.lodestar.model.pagination.PagedEngagementResults;
+import com.redhat.labs.lodestar.model.pagination.PagedHostingEnvironmentResults;
+import com.redhat.labs.lodestar.model.pagination.PagedScoreResults;
 import com.redhat.labs.lodestar.model.pagination.PagedStringResults;
+import com.redhat.labs.lodestar.model.pagination.PagedUseCaseResults;
 import com.redhat.labs.lodestar.repository.EngagementRepository;
 import com.redhat.labs.lodestar.rest.client.LodeStarGitLabAPIService;
 
@@ -398,6 +406,83 @@ public class EngagementService {
 
         }
 
+        // set ids and/or time stamps for modified attributes
+        setIdsAndTimestamps(engagement, existing);
+
+    }
+
+    /**
+     * Updates the UUID and/or timestamps if the {@link Artifact}, {@link Category},
+     * {@link UseCase}, {@link Score}, or {@link HostingEnvironment} is new or has
+     * been modified.
+     * 
+     * @param engagement
+     * @param existing
+     */
+    void setIdsAndTimestamps(Engagement engagement, Engagement existing) {
+
+        // categories
+        setIdAndTimstampsOnEngagementAttribute(engagement.getCategories(), existing.getCategories());
+
+        // artifacts
+        setIdAndTimstampsOnEngagementAttribute(engagement.getArtifacts(), existing.getArtifacts());
+
+        // use cases
+        setIdAndTimstampsOnEngagementAttribute(engagement.getUseCases(), existing.getUseCases());
+
+        // scores
+        setIdAndTimstampsOnEngagementAttribute(engagement.getScores(), existing.getScores());
+
+        // hosting environments
+        setIdAndTimstampsOnEngagementAttribute(engagement.getHostingEnvironments(), existing.getHostingEnvironments());
+
+    }
+
+    /**
+     * For each {@link EngagementAttribute} in the {@link List} of incoming, if the
+     * attribute is new the UUID, created and updated timestamps will be set. If the
+     * attribute exists in the {@link List} of existing, the updated timestamp will
+     * be updated in it has been modified. Otherwise, nothing will be updated.
+     * 
+     * @param incoming
+     * @param existing
+     */
+    void setIdAndTimstampsOnEngagementAttribute(List<? extends EngagementAttribute> incoming,
+            List<? extends EngagementAttribute> existing) {
+
+        // nothing to do if incoming is null
+        if (null == incoming) {
+            return;
+        }
+
+        // all new, set id and time stamps
+        if (existing == null) {
+            setIdAndTimestampsOnEngagementAttributes(incoming);
+            return;
+        }
+
+        // check if each attribute in incoming already exists, if true, and modified,
+        // set updated ts
+        incoming.stream().forEach(ia -> {
+
+            // need list of new and already exists
+            Optional<? extends EngagementAttribute> optional = existing.stream()
+                    .filter(ea -> null != ia.getUuid() && ia.getUuid().equals(ea.getUuid())).findAny();
+            if (optional.isPresent()) {
+
+                // set updated ts if modified
+                if (!ia.equals(optional.get())) {
+                    ia.setUpdated();
+                }
+
+            } else {
+
+                setIdAndTimestamps(ia);
+
+            }
+
+        });
+
     }
 
     /**
@@ -678,6 +763,29 @@ public class EngagementService {
     }
 
     /**
+     * Returns a {@link PagedArtifactResults} that match the provided
+     * {@link ListFilterOptions}. Otherwise, all {@link Artifact}s returned.
+     * 
+     * @param filterOptions
+     * @return
+     */
+    public PagedArtifactResults getArtifacts(ListFilterOptions filterOptions) {
+        return repository.findArtifacts(filterOptions);
+    }
+
+    public PagedHostingEnvironmentResults getHostingEnvironments(ListFilterOptions filterOptions) {
+        return repository.findHostingEnvironments(filterOptions);
+    }
+
+    public PagedScoreResults getScores(ListFilterOptions filterOptions) {
+        return repository.findScores(filterOptions);
+    }
+
+    public PagedUseCaseResults getUseCases(ListFilterOptions filterOptions) {
+        return repository.findUseCases(filterOptions);
+    }
+
+    /**
      * Sets a generated UUID value for each {@link Engagement} or
      * {@link EngagementUser} in the data store that does not have a UUID. Also,
      * triggers a push to Git to make sure the UUID value(s) are set in case of a
@@ -719,7 +827,10 @@ public class EngagementService {
         // set engagement user(s) uuids if required
         boolean uUuidSet = setUuidOnUsers(engagement.getEngagementUsers());
 
-        return eUuidSet || uUuidSet;
+        // set other attribute uuids if required
+        boolean aUuidSet = setUuidOnEngagementAttributes(engagement);
+
+        return eUuidSet || uUuidSet || aUuidSet;
 
     }
 
@@ -765,6 +876,88 @@ public class EngagementService {
         }
 
         return false;
+
+    }
+
+    /**
+     * Returns true if any {@link Artifact}, {@link Category}, {@link UseCase},
+     * {@link Score}, or {@link HostingEnvironment} has its UUID or timestamps
+     * updated. Otherwise, false.
+     * 
+     * @param engagement
+     * @return
+     */
+    boolean setUuidOnEngagementAttributes(Engagement engagement) {
+
+        boolean updated = false;
+
+        // artifacts
+        if (setIdAndTimestampsOnEngagementAttributes(engagement.getArtifacts())) {
+            updated = true;
+        }
+
+        // categories
+        if (setIdAndTimestampsOnEngagementAttributes(engagement.getCategories())) {
+            updated = true;
+        }
+
+        // use cases
+        if (setIdAndTimestampsOnEngagementAttributes(engagement.getUseCases())) {
+            updated = true;
+        }
+
+        // scores
+        if (setIdAndTimestampsOnEngagementAttributes(engagement.getScores())) {
+            updated = true;
+        }
+
+        // hosting environments
+        if (setIdAndTimestampsOnEngagementAttributes(engagement.getHostingEnvironments())) {
+            updated = true;
+        }
+
+        return updated;
+
+    }
+
+    /**
+     * Returns true if any {@link EngagementAttribute} has its UUID or timestamps
+     * updated. Otherwise, false.
+     * 
+     * @param attributes
+     * @return
+     */
+    boolean setIdAndTimestampsOnEngagementAttributes(List<? extends EngagementAttribute> attributes) {
+
+        if (null != attributes) {
+            return attributes.stream().map(this::setIdAndTimestamps).collect(Collectors.toSet()).contains(Boolean.TRUE);
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Returns true if the UUID is set and the created and updated timestamps are
+     * set. Otherwise, false.
+     * 
+     * @param attribute
+     * @return
+     */
+    Boolean setIdAndTimestamps(EngagementAttribute attribute) {
+
+        if (null == attribute.getUuid()) {
+
+            // generate id
+            attribute.generateId();
+            // set both created and updated
+            attribute.setCreatedAndUpdated();
+
+            return Boolean.TRUE;
+
+        }
+
+        return Boolean.FALSE;
 
     }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -889,34 +889,22 @@ public class EngagementService {
      */
     boolean setUuidOnEngagementAttributes(Engagement engagement) {
 
-        boolean updated = false;
-
         // artifacts
-        if (setIdAndTimestampsOnEngagementAttributes(engagement.getArtifacts())) {
-            updated = true;
-        }
+        boolean aModified = setIdAndTimestampsOnEngagementAttributes(engagement.getArtifacts());
 
         // categories
-        if (setIdAndTimestampsOnEngagementAttributes(engagement.getCategories())) {
-            updated = true;
-        }
+        boolean cModified = setIdAndTimestampsOnEngagementAttributes(engagement.getCategories());
 
         // use cases
-        if (setIdAndTimestampsOnEngagementAttributes(engagement.getUseCases())) {
-            updated = true;
-        }
+        boolean uModified = setIdAndTimestampsOnEngagementAttributes(engagement.getUseCases());
 
         // scores
-        if (setIdAndTimestampsOnEngagementAttributes(engagement.getScores())) {
-            updated = true;
-        }
+        boolean sModified = setIdAndTimestampsOnEngagementAttributes(engagement.getScores());
 
         // hosting environments
-        if (setIdAndTimestampsOnEngagementAttributes(engagement.getHostingEnvironments())) {
-            updated = true;
-        }
+        boolean hModified = setIdAndTimestampsOnEngagementAttributes(engagement.getHostingEnvironments());
 
-        return updated;
+        return aModified || cModified || uModified || sModified || hModified;
 
     }
 

--- a/src/main/java/com/redhat/labs/lodestar/util/ClassFieldUtils.java
+++ b/src/main/java/com/redhat/labs/lodestar/util/ClassFieldUtils.java
@@ -6,10 +6,13 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.ws.rs.WebApplicationException;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
 
 public class ClassFieldUtils {
 
@@ -27,7 +30,7 @@ public class ClassFieldUtils {
 
     public static String snakeToCamelCase(String value) {
 
-        if(!value.contains("_")) {
+        if (!value.contains("_")) {
             return value;
         }
 
@@ -45,6 +48,16 @@ public class ClassFieldUtils {
         });
 
         return builder.toString();
+
+    }
+
+    public static String classFieldNamesAsCommaSeparatedString(Class<?> clazz, Optional<String> prefix) {
+
+        Field[] fields = FieldUtils.getAllFields(clazz);
+        List<String> names = Stream.of(fields).map(f -> ClassFieldUtils.getNestedFieldName(f.getName(), prefix))
+                .collect(Collectors.toList());
+
+        return String.join(",", names);
 
     }
 
@@ -126,6 +139,11 @@ public class ClassFieldUtils {
             throw new WebApplicationException(String.format("invalid field %s on %s", fieldName, clazz.getName()), 400);
         }
 
+    }
+
+    static String getNestedFieldName(String fieldName, Optional<String> prefix) {
+        return prefix.isPresent() ? new StringBuilder(prefix.get()).append(".").append(fieldName).toString()
+                : fieldName;
     }
 
 }

--- a/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceGetTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceGetTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Optional;
 
@@ -20,14 +21,22 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.google.common.collect.Lists;
+import com.redhat.labs.lodestar.model.Artifact;
 import com.redhat.labs.lodestar.model.Category;
 import com.redhat.labs.lodestar.model.Engagement;
 import com.redhat.labs.lodestar.model.EngagementUserSummary;
+import com.redhat.labs.lodestar.model.HostingEnvironment;
+import com.redhat.labs.lodestar.model.Score;
+import com.redhat.labs.lodestar.model.UseCase;
 import com.redhat.labs.lodestar.model.filter.FilterOptions;
 import com.redhat.labs.lodestar.model.filter.ListFilterOptions;
+import com.redhat.labs.lodestar.model.pagination.PagedArtifactResults;
 import com.redhat.labs.lodestar.model.pagination.PagedCategoryResults;
 import com.redhat.labs.lodestar.model.pagination.PagedEngagementResults;
+import com.redhat.labs.lodestar.model.pagination.PagedHostingEnvironmentResults;
+import com.redhat.labs.lodestar.model.pagination.PagedScoreResults;
 import com.redhat.labs.lodestar.model.pagination.PagedStringResults;
+import com.redhat.labs.lodestar.model.pagination.PagedUseCaseResults;
 import com.redhat.labs.lodestar.utils.IntegrationTestHelper;
 import com.redhat.labs.lodestar.utils.MockUtils;
 import com.redhat.labs.lodestar.utils.TokenUtils;
@@ -275,7 +284,7 @@ class EngagementResourceGetTest extends IntegrationTestHelper {
     }
     
     @Test
-    void testGetArtifacts() throws Exception {
+    void testGetArtifactTypes() throws Exception {
 
         HashMap<String, Long> timeClaims = new HashMap<>();
         String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
@@ -293,6 +302,98 @@ class EngagementResourceGetTest extends IntegrationTestHelper {
         .then()
             .statusCode(200)
             .body(containsString("a1"));
+
+    }
+
+    @Test
+    void testGetArtifacts() throws Exception {
+
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
+
+        Artifact a1 = MockUtils.mockArtifact("demo 1", "demo", "http://demo-1");
+        PagedArtifactResults pagedResults = PagedArtifactResults.builder().results(Arrays.asList(a1)).build();
+        Mockito.when(eRepository.findArtifacts(Mockito.any(ListFilterOptions.class))).thenReturn(pagedResults);
+
+        given()
+            .auth()
+            .oauth2(token)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("/engagements/artifacts")
+        .then()
+            .statusCode(200)
+            .body(containsString("demo 1"))
+            .body(containsString("http://demo-1"));
+
+    }
+
+    @Test
+    void testGetScores() throws Exception {
+
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
+
+        Score score = Score.builder().name("score1").value(88.8).build();
+        PagedScoreResults pagedResults = PagedScoreResults.builder().results(Arrays.asList(score)).build();
+        Mockito.when(eRepository.findScores(Mockito.any(ListFilterOptions.class))).thenReturn(pagedResults);
+
+        given()
+            .auth()
+            .oauth2(token)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("/engagements/scores")
+        .then()
+            .statusCode(200)
+            .body(containsString("score1"))
+            .body(containsString("88.8"));
+
+    }
+
+    @Test
+    void testGetHostingEnvironments() throws Exception {
+
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
+
+        HostingEnvironment he = MockUtils.mockHostingEnvironment("env1", "env-one");
+        PagedHostingEnvironmentResults pagedResults = PagedHostingEnvironmentResults.builder().results(Arrays.asList(he)).build();
+        Mockito.when(eRepository.findHostingEnvironments(Mockito.any(ListFilterOptions.class))).thenReturn(pagedResults);
+
+        given()
+            .auth()
+            .oauth2(token)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("engagements/hosting/environments")
+        .then()
+            .statusCode(200)
+            .body(containsString("env1"))
+            .body(containsString("env-one"));
+
+    }
+
+    @Test
+    void testGetUseCase() throws Exception {
+
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
+
+        UseCase u1 = MockUtils.mockUseCase("usecase1", "use case 1", 0);
+        PagedUseCaseResults pagedResults = PagedUseCaseResults.builder().results(Arrays.asList(u1)).build();
+        Mockito.when(eRepository.findUseCases(Mockito.any(ListFilterOptions.class))).thenReturn(pagedResults);
+
+        given()
+            .auth()
+            .oauth2(token)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("engagements/usecases")
+        .then()
+            .statusCode(200)
+            .body(containsString("usecase1"))
+            .body(containsString("use case 1"));
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/utils/MockUtils.java
+++ b/src/test/java/com/redhat/labs/lodestar/utils/MockUtils.java
@@ -15,7 +15,9 @@ import com.redhat.labs.lodestar.model.GitlabProject;
 import com.redhat.labs.lodestar.model.Hook;
 import com.redhat.labs.lodestar.model.HostingEnvironment;
 import com.redhat.labs.lodestar.model.Launch;
+import com.redhat.labs.lodestar.model.Score;
 import com.redhat.labs.lodestar.model.Status;
+import com.redhat.labs.lodestar.model.UseCase;
 
 public class MockUtils {
 
@@ -100,5 +102,13 @@ public class MockUtils {
     public static Launch mockLaunch(String dateTime, String launchedBy, String launchedByEmail) {
         return Launch.builder().launchedDateTime(dateTime).launchedBy(launchedBy).launchedByEmail(launchedByEmail)
                 .build();
+    }
+
+    public static UseCase mockUseCase(String title, String description, Integer order) {
+        return UseCase.builder().title(title).description(description).order(order).build();
+    }
+
+    public static Score mockScore(String name, Double value) {
+        return Score.builder().name(name).value(value).build();
     }
 }


### PR DESCRIPTION
- Created EngagementAttribute Parent class to define the following attributes:
  - uuid - unique id for an attribute
  - created - timestamp for the creation of the attribute
  - updated - timestamp for the last update of the attribute
  - engagementUuid - unique id for the attributes parent engagement
- Artifact, UseCase, Category, HostingEnvironment, and Score extend EngagementAttribute
- Created new or separated nested object resources from EngagementResource
  - EngagementArtifactResource - query artifacts across engagements
  - EngagementUseCaseResource - query use cases across engagements
  - EngagementCategoryResource - query for category name/count
  - EngagementHostingEnvironmentResource - query for hosting environments across engagements
  - EngagementScoreEnvironmentResource - query for scores across engagements
- Updated Set UUID API to add UUIDs and timestamps for nested objects if not already set