### PR TITLE
Allow unlaunch and Fix Potential Data Issue

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -534,60 +534,6 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
 
     }
 
-//    /**
-//     * Returns a {@link Map} containing the field names and values.
-//     * 
-//     * @param engagement
-//     * @return
-//     */
-//    Map<String, Object> createUpdateMap(Engagement engagement) {
-//
-//        TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {
-//        };
-//        Map<String, Object> map = objectMapper.convertValue(engagement, typeRef);
-//
-//        // remove null values
-//        return map.entrySet().stream().filter(e -> !isNullOrEmpty(e.getValue()))
-//                .map(k -> {
-//                    System.out.println("---->"+k);
-//                    return k;
-//                })
-//                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-//
-//    }
-//
-//    /**
-//     * Returns true if obj is null or if it is a {@link List} or {@link Map} that
-//     * contains no elements.
-//     * 
-//     * @param obj
-//     * @return
-//     */
-//    @SuppressWarnings("rawtypes")
-//    boolean isNullOrEmpty(Object obj) {
-//        return null == obj || (obj instanceof List && ((List) obj).isEmpty())
-//                || (obj instanceof Map && ((Map) obj).keySet().isEmpty());
-//    }
-//
-//    /**
-//     * Returns a {@link String} containing the Mongo Panache set query for values in
-//     * the given {@link Map}.
-//     * 
-//     * @param map
-//     * @return
-//     */
-//    String createSetQueryString(Map<String, Object> map) {
-//
-//        // create a query for each map entry
-//        List<String> queries = map.keySet().stream()
-//                .map(k -> new StringBuilder("'").append(k).append("'").append(" : :").append(k).toString())
-//                .collect(Collectors.toList());
-//
-//        // join each query
-//        return new StringBuilder("{").append(String.join(", ", queries)).append("}").toString();
-//
-//    }
-
     /**
      * Returns a FindIterable with the resulting {@link Bson} filter or all if no
      * filter provided. A projection is added if either the include or exclude is

--- a/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
+++ b/src/main/java/com/redhat/labs/lodestar/repository/EngagementRepository.java
@@ -5,10 +5,8 @@ import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Projections.exclude;
 import static com.mongodb.client.model.Projections.include;
-import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.set;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -61,10 +59,6 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
     private static final String ARTIFACTS = "artifacts";
     private static final String ARTIFACTS_TYPE = new StringBuilder(ARTIFACTS).append(".").append(TYPE).toString();
     private static final String COUNT = "count";
-    private static final String LAUNCH = "launch";
-
-    private static final List<String> IMMUTABLE_FIELDS = new ArrayList<>(
-            Arrays.asList("uuid", "mongoId", "projectId", "creationDetails", "status", "commits", LAUNCH));
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -130,24 +124,23 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
     }
 
     /**
-     * Returns an {@link Optional} containing the updated {@link Engagement} where
-     * last update matched. Otherwise, returns an empty {@link Optional}
+     * Returns 1 if the {@link Engagement} was updated where last update matched.
+     * Otherwise, returns 0.
      * 
-     * @param replacement
+     * @param toUpdate
      * @param lastUpdate
-     * @param skipLaunch
      * @return
      */
-    public Optional<Engagement> updateEngagementIfLastUpdateMatched(Engagement toUpdate, String lastUpdate,
-            Boolean skipLaunch) {
+    public long updateEngagement(Engagement toUpdate, String lastUpdate) {
 
-        // create the bson for filter and update
-        Bson filter = createFilterForEngagement(toUpdate, lastUpdate);
-        Bson update = createUpdateDocument(toUpdate, skipLaunch);
+        // create engagement map
+        Map<String, Object> map = createUpdateMap(toUpdate);
 
-        FindOneAndUpdateOptions optionAfter = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
+        // create query
+        String query = createSetQueryString(map);
 
-        return Optional.ofNullable(this.mongoCollection().findOneAndUpdate(filter, update, optionAfter));
+        // update
+        return this.update(query, map).where("lastUpdate", lastUpdate);
 
     }
 
@@ -497,55 +490,38 @@ public class EngagementRepository implements PanacheMongoRepository<Engagement> 
      */
 
     /**
-     * Returns a {@link Bson} containing the filter to find {@link Engagement} with
-     * the corresponding customer name, project name, and last update timestamp.
+     * Returns a {@link Map} containing the field names and values.
      * 
      * @param engagement
-     * @param lastUpdate
      * @return
      */
-    private Bson createFilterForEngagement(Engagement engagement, String lastUpdate) {
-        return and(eq("uuid", engagement.getUuid()), eq("lastUpdate", lastUpdate));
+    Map<String, Object> createUpdateMap(Engagement engagement) {
+
+        TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {
+        };
+        return objectMapper.convertValue(engagement, typeRef);
+
     }
 
     /**
-     * Returns a {@link Bson} containing the fields to be updated for a given
-     * {@link Engagement}.
+     * Returns a {@link String} containing the Mongo Panache set query for values in
+     * the given {@link Map}.
      * 
-     * @param engagement
-     * @param skipLaunch
+     * @param map
      * @return
      */
-    private Bson createUpdateDocument(Engagement engagement, boolean skipLaunch) {
+    String createSetQueryString(Map<String, Object> map) {
 
-        Bson updates = null;
+        // filter immutable and nulls
+        Map<String, Object> srubbedMap = map.entrySet().stream().filter(e -> null != e.getValue())
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
-        // convert to map
-        TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {
-        };
-        Map<String, Object> fieldMap = objectMapper.convertValue(engagement, typeRef);
+        // create a query for each map entry
+        List<String> queries = srubbedMap.keySet().stream()
+                .map(k -> new StringBuilder(k).append(" = :").append(k).toString()).collect(Collectors.toList());
 
-        // remove values that should not be updated
-        IMMUTABLE_FIELDS.forEach(f -> {
-            if (!f.equals(LAUNCH) || skipLaunch) {
-                fieldMap.remove(f);
-            }
-        });
-
-        // add a set for each field in the update
-        for (Entry<String, Object> entry : fieldMap.entrySet()) {
-
-            Bson update = set(entry.getKey(), entry.getValue());
-
-            if (null == updates) {
-                updates = update;
-            } else {
-                updates = combine(updates, update);
-            }
-
-        }
-
-        return updates;
+        // join each query
+        return String.join(",", queries);
 
     }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -202,12 +202,11 @@ public class EngagementService {
                 () -> new WebApplicationException("no engagement found, use POST to create", HttpStatus.SC_NOT_FOUND));
 
         String currentLastUpdated = engagement.getLastUpdate();
+
         validateHostingEnvironments(engagement.getHostingEnvironments());
         validateSubdomainOnUpdate(engagement);
         validateCustomerAndProjectNames(engagement, existing);
         setBeforeUpdate(engagement, existing);
-
-        boolean skipLaunch = skipLaunch(existing);
 
         // create copy to send to git api
         Engagement copy = clone(engagement);
@@ -218,15 +217,17 @@ public class EngagementService {
             engagement.getEngagementUsers().stream().forEach(u -> u.setReset(false));
         }
 
-        Engagement updated = repository.updateEngagementIfLastUpdateMatched(engagement, currentLastUpdated, skipLaunch)
-                .orElseThrow(() -> new WebApplicationException(
-                        "Failed to modify engagement because request contained stale data.  Please refresh and try again.",
-                        HttpStatus.SC_CONFLICT));
+        long updated = repository.updateEngagement(engagement, currentLastUpdated);
+        if (0 == updated) {
+            throw new WebApplicationException(
+                    "Failed to modify engagement because request contained stale data.  Please refresh and try again.",
+                    HttpStatus.SC_CONFLICT);
+        }
 
         // send update engagement event once saved
         eventBus.sendAndForget(EventType.UPDATE_ENGAGEMENT_EVENT_ADDRESS, copy);
 
-        return updated;
+        return engagement;
 
     }
 
@@ -389,6 +390,8 @@ public class EngagementService {
      */
     void setBeforeUpdate(Engagement engagement, Engagement existing) {
 
+        setImmutableFieldsOnUpdate(engagement, existing);
+
         setLastUpdate(engagement);
 
         // create new or use existing uuids for users
@@ -412,6 +415,35 @@ public class EngagementService {
 
         // set ids and/or time stamps for modified attributes
         setIdsAndTimestamps(engagement, existing);
+
+    }
+
+    /**
+     * Uses values from the existing {@link Engagement} to set fields that should be
+     * immutable.
+     * 
+     * @param engagement
+     * @param existing
+     */
+    void setImmutableFieldsOnUpdate(Engagement engagement, Engagement existing) {
+
+        // uuid
+        engagement.setUuid(existing.getUuid());
+
+        // mongo id
+        engagement.setMongoId(existing.getMongoId());
+
+        // project id
+        engagement.setProjectId(existing.getProjectId());
+
+        // creation details
+        engagement.setCreationDetails(existing.getCreationDetails());
+
+        // status
+        engagement.setStatus(existing.getStatus());
+
+        // commits
+        engagement.setCommits(existing.getCommits());
 
     }
 
@@ -536,17 +568,6 @@ public class EngagementService {
     }
 
     /**
-     * Returns true if the {@link Launch} data is present on the {@link Engagement}.
-     * Otherwise, false.
-     * 
-     * @param engagement
-     * @return
-     */
-    boolean skipLaunch(Engagement engagement) {
-        return (null != engagement.getLaunch());
-    }
-
-    /**
      * Sets the project ID for the {@link Engagement} with the matching UUID.
      * 
      * @param uuid
@@ -640,19 +661,19 @@ public class EngagementService {
                         "no engagement found with customer:project " + customerName + ":" + projectName,
                         HttpStatus.SC_NOT_FOUND));
     }
-    
+
     public Map<EngagementState, Integer> getEngagementCountByStatus(LocalDateTime currentTime) {
-        
+
         List<Engagement> engagementList = repository.listAll();
         Map<EngagementState, Integer> statusCounts = new EnumMap<>(EngagementState.class);
-        
+
         for (Engagement engagement : engagementList) {
-            EngagementState state =  engagement.getEngagementCurrentState(currentTime);
-            
+            EngagementState state = engagement.getEngagementCurrentState(currentTime);
+
             int count = statusCounts.containsKey(state) ? statusCounts.get(state) + 1 : 1;
             statusCounts.put(state, count);
         }
-        
+
         statusCounts.put(EngagementState.ANY, engagementList.size());
 
         return statusCounts;
@@ -1021,7 +1042,7 @@ public class EngagementService {
 
             engagement.setLastUpdate(getZuluTimeAsString());
             repository.persist(engagement);
-            
+
             return true;
 
         }

--- a/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceUpdateTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceUpdateTest.java
@@ -46,7 +46,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setDescription("testing");
 
         Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()), Mockito.any())).thenReturn(Optional.of(toUpdate));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
 
         String body = quarkusJsonb.toJson(toUpdate);
 
@@ -145,7 +145,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setEngagementUsers(Sets.newHashSet(user1, user2, user3));
 
         Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()), Mockito.any())).thenReturn(Optional.of(toUpdate));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
 
         String body = quarkusJsonb.toJson(toUpdate);
 
@@ -208,7 +208,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setDescription("testing");
 
         Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()), Mockito.any())).thenReturn(Optional.of(toUpdate));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
 
         String body = quarkusJsonb.toJson(toUpdate);
         
@@ -358,7 +358,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setDescription("testing");
 
         Mockito.when(eRepository.findByCustomerNameAndProjectName("c1", "e2")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()), Mockito.any())).thenReturn(Optional.of(toUpdate));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
 
         String body = quarkusJsonb.toJson(toUpdate);
 

--- a/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceUpdateTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceUpdateTest.java
@@ -46,7 +46,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setDescription("testing");
 
         Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Optional.of(toUpdate));
 
         String body = quarkusJsonb.toJson(toUpdate);
 
@@ -145,7 +145,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setEngagementUsers(Sets.newHashSet(user1, user2, user3));
 
         Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Optional.of(toUpdate));
 
         String body = quarkusJsonb.toJson(toUpdate);
 
@@ -208,7 +208,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setDescription("testing");
 
         Mockito.when(eRepository.findByUuid("1234")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Optional.of(toUpdate));
 
         String body = quarkusJsonb.toJson(toUpdate);
         
@@ -358,7 +358,7 @@ class EngagementResourceUpdateTest extends IntegrationTestHelper {
         toUpdate.setDescription("testing");
 
         Mockito.when(eRepository.findByCustomerNameAndProjectName("c1", "e2")).thenReturn(Optional.of(persisted));
-        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Long.valueOf(1));
+        Mockito.when(eRepository.updateEngagement(Mockito.any(), Mockito.eq(toUpdate.getLastUpdate()))).thenReturn(Optional.of(toUpdate));
 
         String body = quarkusJsonb.toJson(toUpdate);
 

--- a/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
@@ -293,7 +293,7 @@ class EngagementServiceTest {
         Mockito.when(repository.findByCustomerNameAndProjectName("c3", "p3", new FilterOptions()))
                 .thenReturn(Optional.empty());
         Mockito.when(repository.updateEngagement(Mockito.any(), Mockito.any()))
-                .thenReturn(Long.valueOf(1));
+                .thenReturn(Optional.of(toUpdate));
 
         Engagement updated = service.update(toUpdate);
         assertNotNull(updated);
@@ -326,7 +326,7 @@ class EngagementServiceTest {
         Mockito.when(repository.findByCustomerNameAndProjectName("c3", "p3", new FilterOptions()))
                 .thenReturn(Optional.empty());
         Mockito.when(repository.updateEngagement(Mockito.any(), Mockito.any()))
-                .thenReturn(Long.valueOf(1));
+                .thenReturn(Optional.of(toUpdate));
 
         Engagement updated = service.update(toUpdate);
         assertNotNull(updated);
@@ -837,7 +837,7 @@ class EngagementServiceTest {
 
         Mockito.when(repository.findByUuid("1234")).thenReturn(Optional.of(persisted));
         Mockito.when(repository.updateEngagement(Mockito.any(), Mockito.any()))
-                .thenReturn(Long.valueOf(1));
+                .thenReturn(Optional.of(toUpdate));
 
         Engagement updated = service.launch(toUpdate);
         assertNotNull(updated);

--- a/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
@@ -292,8 +292,8 @@ class EngagementServiceTest {
         Mockito.when(repository.findByUuid("1234")).thenReturn(Optional.of(persisted));
         Mockito.when(repository.findByCustomerNameAndProjectName("c3", "p3", new FilterOptions()))
                 .thenReturn(Optional.empty());
-        Mockito.when(repository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Optional.of(toUpdate));
+        Mockito.when(repository.updateEngagement(Mockito.any(), Mockito.any()))
+                .thenReturn(Long.valueOf(1));
 
         Engagement updated = service.update(toUpdate);
         assertNotNull(updated);
@@ -325,8 +325,8 @@ class EngagementServiceTest {
         Mockito.when(repository.findByUuid("1234")).thenReturn(Optional.of(persisted));
         Mockito.when(repository.findByCustomerNameAndProjectName("c3", "p3", new FilterOptions()))
                 .thenReturn(Optional.empty());
-        Mockito.when(repository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Optional.of(toUpdate));
+        Mockito.when(repository.updateEngagement(Mockito.any(), Mockito.any()))
+                .thenReturn(Long.valueOf(1));
 
         Engagement updated = service.update(toUpdate);
         assertNotNull(updated);
@@ -836,14 +836,14 @@ class EngagementServiceTest {
         persisted.setProjectId(1111);
 
         Mockito.when(repository.findByUuid("1234")).thenReturn(Optional.of(persisted));
-        Mockito.when(repository.updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Optional.of(toUpdate));
+        Mockito.when(repository.updateEngagement(Mockito.any(), Mockito.any()))
+                .thenReturn(Long.valueOf(1));
 
         Engagement updated = service.launch(toUpdate);
         assertNotNull(updated);
         assertNotNull(updated.getLaunch());
 
-        Mockito.verify(repository).updateEngagementIfLastUpdateMatched(Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(repository).updateEngagement(Mockito.any(), Mockito.any());
         Mockito.verify(eventBus).sendAndForget(Mockito.eq(EventType.UPDATE_ENGAGEMENT_EVENT_ADDRESS), Mockito.any());
 
     }

--- a/src/test/java/com/redhat/labs/lodestar/zrepository/EngagementRepositoryTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/zrepository/EngagementRepositoryTest.java
@@ -131,6 +131,22 @@ class EngagementRepositoryTest {
     // update engagement if last update matched
 
     @Test
+    void testUpdateEngagementIfLastUpdateMatchedMultipleFieldUpdate() throws Exception {
+
+        Engagement e1 = MockUtils.mockMinimumEngagement("c1", "c2", "1234");
+        e1.setLastUpdate("value");
+        repository.persist(e1);
+
+        Engagement e2 = MockUtils.cloneEngagement(e1);
+        e2.setLastUpdate("updated");
+        e2.setDescription("testing");
+
+        Optional<Engagement> optional = repository.updateEngagement(e2, "value");
+        assertTrue(optional.isPresent());
+
+    }
+
+    @Test
     void testUpdateEngagementIfLastUpdateMatched() throws Exception {
 
         Engagement e1 = MockUtils.mockMinimumEngagement("c1", "c2", "1234");
@@ -140,7 +156,8 @@ class EngagementRepositoryTest {
         Engagement e2 = MockUtils.cloneEngagement(e1);
         e2.setDescription("testing");
 
-        assertEquals(1, repository.updateEngagement(e2, "value"));
+        Optional<Engagement> optional = repository.updateEngagement(e2, "value");
+        assertTrue(optional.isPresent());
 
     }
 
@@ -154,7 +171,8 @@ class EngagementRepositoryTest {
         Engagement e2 = MockUtils.cloneEngagement(e1);
         e2.setDescription("testing");
 
-        assertEquals(0, repository.updateEngagement(e2, "value2"));
+        Optional<Engagement> optional = repository.updateEngagement(e2, "value2");
+        assertTrue(optional.isEmpty());
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/zrepository/EngagementRepositoryTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/zrepository/EngagementRepositoryTest.java
@@ -140,8 +140,7 @@ class EngagementRepositoryTest {
         Engagement e2 = MockUtils.cloneEngagement(e1);
         e2.setDescription("testing");
 
-        Optional<Engagement> optional = repository.updateEngagementIfLastUpdateMatched(e2, "value", false);
-        assertTrue(optional.isPresent());
+        assertEquals(1, repository.updateEngagement(e2, "value"));
 
     }
 
@@ -155,8 +154,7 @@ class EngagementRepositoryTest {
         Engagement e2 = MockUtils.cloneEngagement(e1);
         e2.setDescription("testing");
 
-        Optional<Engagement> optional = repository.updateEngagementIfLastUpdateMatched(e2, "value2", false);
-        assertTrue(optional.isEmpty());
+        assertEquals(0, repository.updateEngagement(e2, "value2"));
 
     }
 


### PR DESCRIPTION
- Launch object of Engagement is now editable after a launch to allow for a manual unlaunch
- Immutable fields moved to EngagementService so that the Engagement updated send to Mongo and GitLab will be in sync.