### PR TITLE
add fix for variable date format

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/exception/mapper/BackendException.java
+++ b/src/main/java/com/redhat/labs/lodestar/exception/mapper/BackendException.java
@@ -1,0 +1,8 @@
+package com.redhat.labs.lodestar.exception.mapper;
+
+public class BackendException extends RuntimeException {
+
+    public BackendException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/redhat/labs/lodestar/util/DateFormatter.java
+++ b/src/main/java/com/redhat/labs/lodestar/util/DateFormatter.java
@@ -1,7 +1,12 @@
 package com.redhat.labs.lodestar.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
 
 /**
  * This class exists because the resource doesn't like a public static instance variable being access and
@@ -9,6 +14,7 @@ import java.time.format.DateTimeFormatter;
  * @return
  */
 public class DateFormatter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateFormatter.class);
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     private static DateFormatter formatter = new DateFormatter();
     
@@ -23,7 +29,18 @@ public class DateFormatter {
     }
     
     public LocalDateTime getDateTime(String dateTime) {
-        return LocalDateTime.parse(dateTime, DATE_FORMAT);
+        List<DateTimeFormatter> formats = List.of(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"),
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME, DateTimeFormatter.ISO_INSTANT);
+
+        for(DateTimeFormatter format : formats) {
+            try {
+                return LocalDateTime.parse(dateTime, format);
+            } catch (DateTimeParseException dpe) {
+                LOGGER.error("date format error {} for {} - {}", dateTime, format, dpe.getMessage());
+            }
+
+        }
+        throw new RuntimeException("Unsupported date format " + dateTime);
     }
 
 }


### PR DESCRIPTION
- Adds a patch for different date formats when getting the current state in the backend. Eventually this data should be cleansed (v2). Supports 3 date formats. Tested against prod data.